### PR TITLE
Assertion bug fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,8 +91,8 @@ include_directories(${FSLAM_BINARY_DIR}/cpp)
 add_subdirectory(cpp/core)
 add_subdirectory(cpp/fastslam1)
 add_subdirectory(cpp/fastslam2)
-enable_testing()
-add_subdirectory(cpp/gtest)
+# enable_testing()
+# add_subdirectory(cpp/gtest)
 
 # Adding test directories
 # add_subdirectory(testcode)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,8 +91,8 @@ include_directories(${FSLAM_BINARY_DIR}/cpp)
 add_subdirectory(cpp/core)
 add_subdirectory(cpp/fastslam1)
 add_subdirectory(cpp/fastslam2)
-# enable_testing()
-# add_subdirectory(cpp/gtest)
+enable_testing()
+add_subdirectory(cpp/gtest)
 
 # Adding test directories
 # add_subdirectory(testcode)

--- a/cpp/core/KF_cholesky_update.cpp
+++ b/cpp/core/KF_cholesky_update.cpp
@@ -1,18 +1,18 @@
 #include "KF_cholesky_update.h"
 
-void KF_cholesky_update(Vector2f &x, Matrix2f &P,Vector2f v,Matrix2f R,Matrix2f H)
+void KF_cholesky_update(Vector2d &x, Matrix2d &P,Vector2d v,Matrix2d R,Matrix2d H)
 {
-    Matrix2f PHt = P*H.transpose();
-    Matrix2f S = H*PHt + R;
+    Matrix2d PHt = P*H.transpose();
+    Matrix2d S = H*PHt + R;
     
     S = (S+S.transpose()) * 0.5; //make symmetric
-    Matrix2f SChol = S.llt().matrixL();
+    Matrix2d SChol = S.llt().matrixL();
     SChol.transpose();
     SChol.conjugate();
 
-    Matrix2f SCholInv = SChol.inverse(); //tri matrix
-    Matrix2f W1 = PHt * SCholInv;
-    Matrix2f W = W1 * SCholInv.transpose();
+    Matrix2d SCholInv = SChol.inverse(); //tri matrix
+    Matrix2d W1 = PHt * SCholInv;
+    Matrix2d W = W1 * SCholInv.transpose();
 
     x = x + W*v;
     P = P - W1*W1.transpose();

--- a/cpp/core/KF_cholesky_update.h
+++ b/cpp/core/KF_cholesky_update.h
@@ -14,6 +14,6 @@ using namespace Eigen;
     @param[in]  R    	Covariance matrix of measurements.
     @param[in]  H    	Jacobian of h wrt feature states.
  */
-void KF_cholesky_update(Vector2f &x,Matrix2f &P,Vector2f v,Matrix2f R,Matrix2f H);
+void KF_cholesky_update(Vector2d &x,Matrix2d &P,Vector2d v,Matrix2d R,Matrix2d H);
 
 #endif

--- a/cpp/core/KF_joseph_update.cpp
+++ b/cpp/core/KF_joseph_update.cpp
@@ -4,27 +4,27 @@
 
 using namespace std;
 
-void KF_joseph_update(Vector3f &x, Matrix3f &P,float v,float R, Matrix13f H)
+void KF_joseph_update(Vector3d &x, Matrix3d &P,double v,double R, Matrix13d H)
 {
-    VectorXf PHt = P*H.transpose();
-    MatrixXf S = H*PHt;
+    VectorXd PHt = P*H.transpose();
+    MatrixXd S = H*PHt;
     S(0,0) += R;
-    MatrixXf Si = S.inverse();
+    MatrixXd Si = S.inverse();
     Si = make_symmetric(Si);
-    MatrixXf PSD_check = Si.llt().matrixL(); //chol of scalar is sqrt
+    MatrixXd PSD_check = Si.llt().matrixL(); //chol of scalar is sqrt
     PSD_check.transpose();
     PSD_check.conjugate();
 
-    Vector3f W = PHt*Si;
+    Vector3d W = PHt*Si;
     x = x+W*v;
     
     //Joseph-form covariance update
-    Matrix3f eye(P.rows(), P.cols());
+    Matrix3d eye(P.rows(), P.cols());
     eye.setIdentity();
-    Matrix3f C = eye - W*H;
+    Matrix3d C = eye - W*H;
     P = C*P*C.transpose() + W*R*W.transpose();  
 
-    float eps = 2.2204*pow(10.0,-16); //numerical safety 
+    double eps = 2.2204*pow(10.0,-16); //numerical safety 
     P = P+eye*eps;
 
     PSD_check = P.llt().matrixL();
@@ -32,7 +32,7 @@ void KF_joseph_update(Vector3f &x, Matrix3f &P,float v,float R, Matrix13f H)
     PSD_check.conjugate(); //for upper tri
 }
 
-MatrixXf make_symmetric(MatrixXf P)
+MatrixXd make_symmetric(MatrixXd P)
 {
     return (P + P.transpose())*0.5;
 }

--- a/cpp/core/KF_joseph_update.h
+++ b/cpp/core/KF_joseph_update.h
@@ -6,7 +6,7 @@
 
 using namespace Eigen;
 
-void KF_joseph_update(Vector3f &x,Matrix3f &P,float v,float R, Matrix13f H);
-MatrixXf make_symmetric(MatrixXf P);
+void KF_joseph_update(Vector3d &x,Matrix3d &P,double v,double R, Matrix13d H);
+MatrixXd make_symmetric(MatrixXd P);
 
 #endif

--- a/cpp/core/TransformToGlobal.cpp
+++ b/cpp/core/TransformToGlobal.cpp
@@ -1,14 +1,14 @@
 #include "TransformToGlobal.h"
 #include "pi_to_pi.h"
 
-void TransformToGlobal(MatrixXf &p, Vector3f b) 
+void TransformToGlobal(MatrixXd &p, Vector3d b) 
 {
 	//rotate
-	Matrix2f rot(2,2);
+	Matrix2d rot(2,2);
 	rot<<cos(b(2)), -sin(b(2)), sin(b(2)), cos(b(2));
 	
-	MatrixXf p_resized;
-	p_resized = MatrixXf(p);
+	MatrixXd p_resized;
+	p_resized = MatrixXd(p);
 	p_resized.conservativeResize(2,p_resized.cols());
 	p_resized = rot*p_resized;		
 	
@@ -19,7 +19,7 @@ void TransformToGlobal(MatrixXf &p, Vector3f b)
 		p(1,c) = p_resized(1,c)+b(1); 				
 	}
 
-	float input;
+	double input;
 	//if p is a pose and not a point
 	if (p.rows() ==3){
 		for (int k=0; k<p_resized.cols();k++) {

--- a/cpp/core/TransformToGlobal.h
+++ b/cpp/core/TransformToGlobal.h
@@ -6,6 +6,6 @@
 
 using namespace Eigen;
 
-void TransformToGlobal(MatrixXf &p, Vector3f b);
+void TransformToGlobal(MatrixXd &p, Vector3d b);
 
 #endif //TRANSFORMGLOBAL_H

--- a/cpp/core/add_control_noise.cpp
+++ b/cpp/core/add_control_noise.cpp
@@ -3,13 +3,13 @@
 
 using namespace std;
 
-void add_control_noise(float V, float G, Matrix2f Q, int addnoise, float* VnGn) 
+void add_control_noise(double V, double G, Matrix2d Q, int addnoise, double* VnGn) 
 {
 	if (addnoise ==1) {
-		Vector2f A(2);
+		Vector2d A(2);
 		A(0) = V;
 		A(1) = G;
-		Vector2f C(2);
+		Vector2d C(2);
 		C = multivariate_gauss(A,Q,1);
 		VnGn[0] = C(0);
 		VnGn[1] = C(1);

--- a/cpp/core/add_control_noise.h
+++ b/cpp/core/add_control_noise.h
@@ -35,7 +35,7 @@ using namespace Eigen;
     @param[in]  Q        Covariance matrix of V and G.
     @param[in]  addnoise Flag if control noise should be added.
  */
-void add_control_noise(float V, float G, Matrix2f Q, int addnoise,float* VnGn);
+void add_control_noise(double V, double G, Matrix2d Q, int addnoise,double* VnGn);
 
 
 #endif //ADD_CONTROL_NOISE

--- a/cpp/core/add_feature.cpp
+++ b/cpp/core/add_feature.cpp
@@ -37,7 +37,7 @@ void add_feature(Particle &particle, vector<Vector2d> z, Matrix2d R)
     }	
 
     for(int j=0; j<ii.size(); j++) {
-	particle.setXdi(ii[j],xf[j]);
+	particle.setXfi(ii[j],xf[j]);
     }
 
 

--- a/cpp/core/add_feature.cpp
+++ b/cpp/core/add_feature.cpp
@@ -5,15 +5,15 @@
 
 using namespace std;
 
-void add_feature(Particle &particle, vector<Vector2f> z, Matrix2f R)
+void add_feature(Particle &particle, vector<Vector2d> z, Matrix2d R)
 {
     int lenz = z.size();
-    vector<Vector2f> xf;
-    vector<Matrix2f> Pf;
-    Vector3f xv = particle.xv();
+    vector<Vector2d> xf;
+    vector<Matrix2d> Pf;
+    Vector3d xv = particle.xv();
 
-    float r,b,s,c;
-    Matrix2f Gz(2,2);
+    double r,b,s,c;
+    Matrix2d Gz(2,2);
 
     for (int i=0; i<lenz; i++) {
 	r = z[i][0];
@@ -21,7 +21,7 @@ void add_feature(Particle &particle, vector<Vector2f> z, Matrix2f R)
 	s = sin(xv(2)+b);
 	c = cos(xv(2)+b);
 
-	Vector2f measurement(2);
+	Vector2d measurement(2);
 	measurement(0) = xv(0) + r*c;
 	measurement(1) = xv(1) + r*s;
 	xf.push_back(measurement);
@@ -37,7 +37,7 @@ void add_feature(Particle &particle, vector<Vector2f> z, Matrix2f R)
     }	
 
     for(int j=0; j<ii.size(); j++) {
-	particle.setXfi(ii[j],xf[j]);
+	particle.setXdi(ii[j],xf[j]);
     }
 
 

--- a/cpp/core/add_feature.h
+++ b/cpp/core/add_feature.h
@@ -14,7 +14,7 @@ using namespace Eigen;
     @param[in]  z        Landmark measurements / observations [meter, radians].
     @param[in]  R        Covariance matrix of observation noises -> configfile.h
  */
-void add_feature(Particle &particle, vector<Vector2f> z, Matrix2f R);
+void add_feature(Particle &particle, vector<Vector2d> z, Matrix2d R);
  
 #endif //ADD_FEATURE_H
 

--- a/cpp/core/add_observation_noise.cpp
+++ b/cpp/core/add_observation_noise.cpp
@@ -1,12 +1,12 @@
 #include "add_observation_noise.h"
 #if 0
 //http://moby.ihme.washington.edu/bradbell/mat2cpp/randn.cpp.xml
-MatrixXf randn(int m, int n) 
+MatrixXd randn(int m, int n) 
 {	
 	// use formula 30.3 of Statistical Distributions (3rd ed)
 	// Merran Evans, Nicholas Hastings, and Brian Peacock
 	int urows = m * n + 1;
-	MatrixXf u(urows, 1);
+	MatrixXd u(urows, 1);
 
 	//u is a random matrix
 	for (int r=0; r<urows; r++) {
@@ -15,11 +15,11 @@ MatrixXf randn(int m, int n)
 		}
 	}
 	
-	MatrixXf x(m,n);
+	MatrixXd x(m,n);
 
 	int i, j, k;
-	float pi = 4. * std::atan(1.f);
-	float square, amp, angle;
+	double pi = 4. * std::atan(1.f);
+	double square, amp, angle;
 	k = 0;
 	for(i = 0; i < m; i++)
 	{	for(j = 0; j < n; j++)
@@ -39,38 +39,38 @@ MatrixXf randn(int m, int n)
 	return x;
 }
 
-MatrixXf rand(int m, int n) 
+MatrixXd rand(int m, int n) 
 {	
-	MatrixXf x(m,n);	
+	MatrixXd x(m,n);	
 	int i, j;
-	float rand_max = float(RAND_MAX);
+	double rand_max = double(RAND_MAX);
 
 	for(i = 0; i < m; i++) {	
 		for(j = 0; j < n; j++)
-			x(i, j) = float(std::rand()) / rand_max;
+			x(i, j) = double(std::rand()) / rand_max;
 	} 
 	return x;
 }
 #endif
 //add random measurement noise. We assume R is diagnoal matrix
-void add_observation_noise(vector<Vector2f> &z, Matrix2f R, int addnoise)
+void add_observation_noise(vector<Vector2d> &z, Matrix2d R, int addnoise)
 {
-    float LO = -1.0f;
-    float HI = 1.0f;
+    double LO = -1.0f;
+    double HI = 1.0f;
 
 	if (addnoise == 1){
 		int len = z.size();	
 		if (len > 0) {
-			//MatrixXf randM1 = nRandMat::randn(1,len);
-            MatrixXf randM1(1,len);
+			//MatrixXd randM1 = nRandMat::randn(1,len);
+            MatrixXd randM1(1,len);
             for (int i=0; i< len; i++) {
-                float r3 = LO + (float)rand()/((float)RAND_MAX/(HI-LO));
+                double r3 = LO + (double)rand()/((double)RAND_MAX/(HI-LO));
                 randM1(0,i) = r3; 
             }
-			//MatrixXf randM2 = nRandMat::randn(1,len);
-			MatrixXf randM2(1,len);
+			//MatrixXd randM2 = nRandMat::randn(1,len);
+			MatrixXd randM2(1,len);
             for (int j=0; j< len; j++) {
-                float r4 = LO + (float)rand()/((float)RAND_MAX/(HI-LO));
+                double r4 = LO + (double)rand()/((double)RAND_MAX/(HI-LO));
                 randM2(0,j) = r4; 
             }
             //cout<<"randM1"<<endl;

--- a/cpp/core/add_observation_noise.h
+++ b/cpp/core/add_observation_noise.h
@@ -9,8 +9,8 @@ using namespace Eigen;
 using namespace std;
 
 namespace nRandMat{
-	MatrixXf randn(int m, int n); //Gaussian distribution
-	MatrixXf rand(int m, int n); //Standard random
+	MatrixXd randn(int m, int n); //Gaussian distribution
+	MatrixXd rand(int m, int n); //Standard random
 }
 
 /*!
@@ -19,6 +19,6 @@ namespace nRandMat{
     @param[in]  R        	Covariance matrix of observation (diagonal).
     @param[in]  addnoise	Flag if obersvation noise should be added.
  */
-void add_observation_noise(vector<Vector2f> &z, Matrix2f R, int addnoise);
+void add_observation_noise(vector<Vector2d> &z, Matrix2d R, int addnoise);
 
 #endif //ADD_OBSERVATION_NOISE_H

--- a/cpp/core/compute_jacobians.cpp
+++ b/cpp/core/compute_jacobians.cpp
@@ -5,17 +5,17 @@
 
 void compute_jacobians(Particle particle, 
 		vector<int> idf, 
-		Matrix2f R, 
-		vector<Vector2f> &zp, //measurement (range, bearing)
-		vector<Matrix23f> *Hv, // jacobians of function h (deriv of h wrt pose)
-		vector<Matrix2f> *Hf, // jacobians of function h (deriv of h wrt mean)
-		vector<Matrix2f> *Sf) //measurement covariance
+		Matrix2d R, 
+		vector<Vector2d> &zp, //measurement (range, bearing)
+		vector<Matrix23d> *Hv, // jacobians of function h (deriv of h wrt pose)
+		vector<Matrix2d> *Hf, // jacobians of function h (deriv of h wrt mean)
+		vector<Matrix2d> *Sf) //measurement covariance
 {
-	Vector3f xv = particle.xv();
+	Vector3d xv = particle.xv();
 
 	int rows = particle.xf().size();
-	vector<Vector2f> xf;
-	vector<Matrix2f> Pf;
+	vector<Vector2d> xf;
+	vector<Matrix2d> Pf;
 
 	unsigned i;
 	int r;
@@ -24,9 +24,9 @@ void compute_jacobians(Particle particle,
 		Pf.push_back((particle.Pf())[idf[i]]); //particle.Pf is a array of matrices
 	}
 
-	float dx,dy,d2,d;
-	Matrix23f HvMat(2,3);
-	Matrix2f HfMat (2,2);
+	double dx,dy,d2,d;
+	Matrix23d HvMat(2,3);
+	Matrix2d HfMat (2,2);
 
 	for (i=0; i<idf.size(); i++) {
 		dx = xf[i](0) - xv(0);
@@ -34,7 +34,7 @@ void compute_jacobians(Particle particle,
 		d2 = pow(dx,2) + pow(dy,2);	
 		d = sqrt(d2);
 
-		Vector2f zp_vec(2);
+		Vector2d zp_vec(2);
 		
 		//predicted observation
 		zp_vec[0] = d;
@@ -54,7 +54,7 @@ void compute_jacobians(Particle particle,
 		Hf->push_back(HfMat);
 
 		//innovation covariance of feature observation given the vehicle'
-		Matrix2f SfMat = HfMat*Pf[i]*HfMat.transpose() + R; 
+		Matrix2d SfMat = HfMat*Pf[i]*HfMat.transpose() + R; 
 		Sf->push_back(SfMat);      
 	}			
 }

--- a/cpp/core/compute_jacobians.h
+++ b/cpp/core/compute_jacobians.h
@@ -20,10 +20,10 @@ using namespace Eigen;
  */
 void compute_jacobians(Particle particle, 
                         vector<int> idf, 
-                        Matrix2f R,
-                        vector<Vector2f> &zp,
-                        vector<Matrix23f> *Hv, 
-                        vector<Matrix2f> *Hf, 
-                        vector<Matrix2f> *Sf);
+                        Matrix2d R,
+                        vector<Vector2d> &zp,
+                        vector<Matrix23d> *Hv, 
+                        vector<Matrix2d> *Hf, 
+                        vector<Matrix2d> *Sf);
 
 #endif //COMPUTE_JACOBIANS_H

--- a/cpp/core/compute_steering.cpp
+++ b/cpp/core/compute_steering.cpp
@@ -8,8 +8,8 @@
 using namespace std;
 
 
-void compute_steering(Vector3f x, MatrixXf wp, int& iwp, float minD, 
-				float& G, float rateG, float maxG, float dt)
+void compute_steering(Vector3d x, MatrixXd wp, int& iwp, double minD, 
+				double& G, double rateG, double maxG, double dt)
 {
 
 		//determine if current waypoint reached
@@ -17,7 +17,7 @@ void compute_steering(Vector3f x, MatrixXf wp, int& iwp, float minD,
 		cwp[0] = wp(0,iwp); //-1 since indexed from 0     
 		cwp[1] = wp(1,iwp);
 
-		float d2 = pow((cwp[0] - x[0]),2) + pow((cwp[1]-x[1]),2);     
+		double d2 = pow((cwp[0] - x[0]),2) + pow((cwp[1]-x[1]),2);     
 
 		if (d2 < minD*minD) {
 				iwp++; //switch to next
@@ -31,11 +31,11 @@ void compute_steering(Vector3f x, MatrixXf wp, int& iwp, float minD,
 		}
 
 		//compute change in G to point towards current waypoint
-		float deltaG = atan2(cwp[1]-x[1], cwp[0]-x[0]) - x[2] - G;
+		double deltaG = atan2(cwp[1]-x[1], cwp[0]-x[0]) - x[2] - G;
 		deltaG = pi_to_pi(deltaG);
 
 		//limit rate
-		float maxDelta = rateG*dt;
+		double maxDelta = rateG*dt;
 		if (abs(deltaG) > maxDelta) {
 				int sign = (deltaG > 0) ? 1 : ((deltaG < 0) ? -1 : 0);
 				deltaG = sign*maxDelta;	

--- a/cpp/core/compute_steering.h
+++ b/cpp/core/compute_steering.h
@@ -16,7 +16,7 @@ using namespace Eigen;
 	@param[in] 	maxG 	max steering angle (rad).
 	@param[in] 	dt 		timestep.
  */
-void compute_steering(Vector3f x, MatrixXf wp, int& iwp, float minD, 
-						float& G, float rateG, float maxG, float dt);
+void compute_steering(Vector3d x, MatrixXd wp, int& iwp, double minD, 
+						double& G, double rateG, double maxG, double dt);
 
 #endif //COMPUTE_STEERING_H

--- a/cpp/core/configfile.cpp
+++ b/cpp/core/configfile.cpp
@@ -7,35 +7,35 @@
 // See fastslam_sim.h for more information
 
 // control parameters
-float config::V= 3.0; // m/s
-float config::MAXG= 30*pi/180; // radians, maximum steering angle (-MAXG < g < MAXG)
-float config::RATEG= 20*pi/180; // rad/s, maximum rate of change in steer angle
-float config::WHEELBASE= 4.; // metres, vehicle wheel-base
-float config::DT_CONTROLS= 0.025; // seconds, time interval between control signals
+double config::V= 3.0; // m/s
+double config::MAXG= 30*pi/180; // radians, maximum steering angle (-MAXG < g < MAXG)
+double config::RATEG= 20*pi/180; // rad/s, maximum rate of change in steer angle
+double config::WHEELBASE= 4.; // metres, vehicle wheel-base
+double config::DT_CONTROLS= 0.025; // seconds, time interval between control signals
 
 // control noises
-float config::sigmaV= 0.3; // m/s
-float config::sigmaG= (3.0*pi/180); // radians
+double config::sigmaV= 0.3; // m/s
+double config::sigmaG= (3.0*pi/180); // radians
 
-Eigen::Matrix2f config::Q(2,2);
+Eigen::Matrix2d config::Q(2,2);
 
 // observation parameters
-float config::MAX_RANGE= 30.0; // metres
-float config::DT_OBSERVE= 8* config::DT_CONTROLS; // seconds, time interval between observations
+double config::MAX_RANGE= 30.0; // metres
+double config::DT_OBSERVE= 8* config::DT_CONTROLS; // seconds, time interval between observations
 
 // observation noises
-float config::sigmaR= 0.1; // metres
-float config::sigmaB= (1.0*pi/180); // radians
+double config::sigmaR= 0.1; // metres
+double config::sigmaB= (1.0*pi/180); // radians
 
-Eigen::Matrix2f config::R(2,2);
+Eigen::Matrix2d config::R(2,2);
 
 // waypoint proximity
-float config::AT_WAYPOINT= 1.0; // metres, distance from current waypoint at which to switch to next waypoint
+double config::AT_WAYPOINT= 1.0; // metres, distance from current waypoint at which to switch to next waypoint
 int config::NUMBER_LOOPS= 2; // number of loops through the waypoint list
 
 // resampling
 unsigned int config::NPARTICLES= 100; 
-float config::NEFFECTIVE= 0.75* config::NPARTICLES; // minimum number of effective particles before resampling
+double config::NEFFECTIVE= 0.75* config::NPARTICLES; // minimum number of effective particles before resampling
 
 // switches
 int config::SWITCH_CONTROL_NOISE= 1;

--- a/cpp/core/configfile.h
+++ b/cpp/core/configfile.h
@@ -8,30 +8,30 @@
 //******************
 
 namespace config {
-		extern float V;
-		extern float MAXG;
-		extern float RATEG;
-		extern float WHEELBASE;
-		extern float DT_CONTROLS;
+		extern double V;
+		extern double MAXG;
+		extern double RATEG;
+		extern double WHEELBASE;
+		extern double DT_CONTROLS;
 
-		extern float sigmaV;
-		extern float sigmaG;
+		extern double sigmaV;
+		extern double sigmaG;
 
-		extern Eigen::Matrix2f Q;
+		extern Eigen::Matrix2d Q;
 
-		extern float MAX_RANGE;
-		extern float DT_OBSERVE;
+		extern double MAX_RANGE;
+		extern double DT_OBSERVE;
 
-		extern float sigmaR;
-		extern float sigmaB;
+		extern double sigmaR;
+		extern double sigmaB;
 		
-		extern Eigen::Matrix2f R;
+		extern Eigen::Matrix2d R;
 
-		extern float AT_WAYPOINT;
+		extern double AT_WAYPOINT;
 		extern int NUMBER_LOOPS;
 
 		extern unsigned int NPARTICLES;
-		extern float NEFFECTIVE;
+		extern double NEFFECTIVE;
 
 		extern int SWITCH_CONTROL_NOISE;
 		extern int SWITCH_SENSOR_NOISE;

--- a/cpp/core/data_associate_known.cpp
+++ b/cpp/core/data_associate_known.cpp
@@ -2,8 +2,8 @@
 #include <iostream>
 
 //z is range and bearing of visible landmarks
-void data_associate_known(vector<Vector2f> z, vector<int> idz, VectorXf &table, int Nf, \
-		vector<Vector2f> &zf, vector<int> &idf, vector<Vector2f> &zn) 
+void data_associate_known(vector<Vector2d> z, vector<int> idz, VectorXd &table, int Nf, \
+		vector<Vector2d> &zf, vector<int> &idf, vector<Vector2d> &zn) 
 {
 	idf.clear();
 	vector<int> idn;
@@ -12,7 +12,7 @@ void data_associate_known(vector<Vector2f> z, vector<int> idz, VectorXf &table, 
 
 	for (i =0; i< idz.size(); i++){
 		ii = idz[i];
-		VectorXf z_i;
+		VectorXd z_i;
 		if (table(ii) ==-1) { //new feature
 			z_i = z[i];
 			zn.push_back(z_i);

--- a/cpp/core/data_associate_known.h
+++ b/cpp/core/data_associate_known.h
@@ -19,7 +19,7 @@ using namespace Eigen;
 	@param[out] 	idf 	Index of known landmarks.
 	@param[out] 	zn	 	New landmarks.
  */
-void data_associate_known(vector<Vector2f> z, vector<int> idz, VectorXf &table, int Nf, \
-						  vector<Vector2f> &zf, vector<int> &idf, vector<Vector2f> &zn); 
+void data_associate_known(vector<Vector2d> z, vector<int> idz, VectorXd &table, int Nf, \
+						  vector<Vector2d> &zf, vector<int> &idf, vector<Vector2d> &zn); 
 
 #endif //DATA_ASSOCIATE_KNOWN_H

--- a/cpp/core/feature_update.cpp
+++ b/cpp/core/feature_update.cpp
@@ -46,7 +46,7 @@ void feature_update(Particle &particle, vector<Vector2d> z, vector<int>idf, Matr
 	}
 
 	for (int i=0; i<idf.size(); i++) {
-		particle.setXdi(idf[i],xf[i]);
+		particle.setXfi(idf[i],xf[i]);
 		particle.setPfi(idf[i],Pf[i]);
 	}
 }

--- a/cpp/core/feature_update.cpp
+++ b/cpp/core/feature_update.cpp
@@ -4,36 +4,36 @@
 using namespace std;
 
 //z is the list of measurements conditioned on the particle.
-void feature_update(Particle &particle, vector<Vector2f> z, vector<int>idf, Matrix2f R)
+void feature_update(Particle &particle, vector<Vector2d> z, vector<int>idf, Matrix2d R)
 {
     //Having selected a new pose from the proposal distribution, this pose is assumed perfect and each feature update maybe computed independently and without pose uncertainty
     int rows = 2; //2d mean for EKF
-    vector<Vector2f> xf; //updated EKF means
-    vector<Matrix2f> Pf; //updated EKF covariances
+    vector<Vector2d> xf; //updated EKF means
+    vector<Matrix2d> Pf; //updated EKF covariances
 
 	for (unsigned i=0; i<idf.size(); i++) {
 		xf.push_back(particle.xf()[idf[i]]); //means
 		Pf.push_back(particle.Pf()[idf[i]]); //covariances
 	}	
 	
-    vector<Vector2f> zp;
-    vector<Matrix23f> Hv;
-    vector<Matrix2f> Hf;
-    vector<Matrix2f> Sf;
+    vector<Vector2d> zp;
+    vector<Matrix23d> Hv;
+    vector<Matrix2d> Hf;
+    vector<Matrix2d> Sf;
     
 	compute_jacobians(particle,idf,R,zp,&Hv,&Hf,&Sf);
 
-	vector<Vector2f> v; //difference btw two measurements (used to update mean)
+	vector<Vector2d> v; //difference btw two measurements (used to update mean)
 	for (int i=0; i<z.size(); i++) {
-		Vector2f measure_diff = z[i] - zp[i];
+		Vector2d measure_diff = z[i] - zp[i];
 		measure_diff[1] = pi_to_pi(measure_diff[1]);
 		v.push_back(measure_diff);
 	}
 
-    Vector2f vi; 
-    Matrix2f Hfi;
-    Matrix2f Pfi;
-    Vector2f xfi; 
+    Vector2d vi; 
+    Matrix2d Hfi;
+    Matrix2d Pfi;
+    Vector2d xfi; 
 
 	for (int i=0; i<idf.size(); i++) {
 		vi = v[i];
@@ -46,7 +46,7 @@ void feature_update(Particle &particle, vector<Vector2f> z, vector<int>idf, Matr
 	}
 
 	for (int i=0; i<idf.size(); i++) {
-		particle.setXfi(idf[i],xf[i]);
+		particle.setXdi(idf[i],xf[i]);
 		particle.setPfi(idf[i],Pf[i]);
 	}
 }

--- a/cpp/core/feature_update.h
+++ b/cpp/core/feature_update.h
@@ -20,6 +20,6 @@ using namespace std;
 	@param[out] 	idf 	    Index of known landmarks.
 	@param[out] 	R	 	    Covariance Matrix of measurements.
  */
-void feature_update(Particle &particle, vector<Vector2f> z, vector<int>idf, Matrix2f R);
+void feature_update(Particle &particle, vector<Vector2d> z, vector<int>idf, Matrix2d R);
 
 #endif

--- a/cpp/core/get_observations.cpp
+++ b/cpp/core/get_observations.cpp
@@ -2,38 +2,38 @@
 #include <iostream>
 #include <math.h>
 
-vector<Vector2f> get_observations(Vector3f x, MatrixXf lm, vector<int> &idf, float rmax)
+vector<Vector2d> get_observations(Vector3d x, MatrixXd lm, vector<int> &idf, double rmax)
 {
 	get_visible_landmarks(x,lm,idf,rmax);
 	return compute_range_bearing(x,lm);	
 }
 
 
-void get_visible_landmarks(Vector3f x, MatrixXf &lm, vector<int> &idf, float rmax)
+void get_visible_landmarks(Vector3d x, MatrixXd &lm, vector<int> &idf, double rmax)
 {
 	//select set of landmarks that are visible within vehicle's 
 	//semi-circular field of view
-	vector<float> dx;
-	vector<float> dy;
+	vector<double> dx;
+	vector<double> dy;
 
 	for (int c=0; c<lm.cols(); c++) {
 		dx.push_back(lm(0,c) - x(0));
 		dy.push_back(lm(1,c) - x(1));
 	}
 
-	float phi = x(2);
+	double phi = x(2);
 
 	//distant points are eliminated
 	vector<int> ii = find2(dx,dy,phi,rmax); 
 
-	MatrixXf lm_new (lm.rows(), ii.size());
+	MatrixXd lm_new (lm.rows(), ii.size());
 	unsigned j,k;
 	for (j=0; j<lm.rows(); j++){
 		for(k=0; k< ii.size(); k++){
 			lm_new(j,k) = lm(j,ii[k]);
 		}
 	}
-	lm = MatrixXf(lm_new); 
+	lm = MatrixXd(lm_new); 
 
 	vector<int> idf_backup(idf);
 	idf.clear();
@@ -42,10 +42,10 @@ void get_visible_landmarks(Vector3f x, MatrixXf &lm, vector<int> &idf, float rma
 	}
 }
 
-vector<Vector2f> compute_range_bearing(Vector3f x, MatrixXf lm) 
+vector<Vector2d> compute_range_bearing(Vector3d x, MatrixXd lm) 
 {
-	vector<float> dx; 
-	vector<float> dy;
+	vector<double> dx; 
+	vector<double> dy;
 
 	for (int c=0; c<lm.cols(); c++) {
 		dx.push_back(lm(0,c) - x(0));
@@ -55,11 +55,11 @@ vector<Vector2f> compute_range_bearing(Vector3f x, MatrixXf lm)
 	assert(dx.size() == lm.cols());
 	assert(dy.size() == lm.cols());
 
-	float phi = x(2);
-	vector<Vector2f> z;
+	double phi = x(2);
+	vector<Vector2d> z;
 
 	for (int i =0; i<lm.cols(); i++) {
-		Vector2f zvec(2);
+		Vector2d zvec(2);
 		zvec<< sqrt(pow(dx[i],2) + pow(dy[i],2)), atan2(dy[i],dx[i]) - phi;	
 		z.push_back(zvec);
 	}
@@ -67,14 +67,14 @@ vector<Vector2f> compute_range_bearing(Vector3f x, MatrixXf lm)
 	return z; 
 }
 
-vector<int> find2(vector<float> dx, vector<float> dy, float phi, float rmax)
+vector<int> find2(vector<double> dx, vector<double> dy, double phi, double rmax)
 {
 	vector<int> index;
 	//incremental tests for bounding semi-circle
 	for (int j=0; j<dx.size(); j++) {
 		if ((abs(dx[j]) < rmax) && (abs(dy[j]) < rmax)
 				&& ((dx[j]* cos(phi) + dy[j]* sin(phi)) > 0.0)
-				&& (((float)pow(dx[j],2) + (float)pow(dy[j],2)) < (float)pow(rmax,2))){
+				&& (((double)pow(dx[j],2) + (double)pow(dy[j],2)) < (double)pow(rmax,2))){
 			index.push_back(j);			
 		}
 	}

--- a/cpp/core/get_observations.h
+++ b/cpp/core/get_observations.h
@@ -19,7 +19,7 @@ using namespace std;
 
     @return Vector of distance and bearing to each landmark.
  */
-vector<Vector2f> get_observations(Vector3f x,MatrixXf lm,vector<int> &idf,float rmax);
+vector<Vector2d> get_observations(Vector3d x,MatrixXd lm,vector<int> &idf,double rmax);
 
 
 /*!
@@ -30,7 +30,7 @@ vector<Vector2f> get_observations(Vector3f x,MatrixXf lm,vector<int> &idf,float 
 	@param[out] idf 	Index of known landmarks. (updated)
 	@param[in] 	rmax 	Maximal distance between x and lm(:,i) to be considered visible.
  */
-void get_visible_landmarks(Vector3f x, MatrixXf &lm,vector<int> &idf, float rmax);
+void get_visible_landmarks(Vector3d x, MatrixXd &lm,vector<int> &idf, double rmax);
 
 /*!
     Computes distance and bearing between x and all landmarks in lm.
@@ -39,7 +39,7 @@ void get_visible_landmarks(Vector3f x, MatrixXf &lm,vector<int> &idf, float rmax
 
     @return Vector  of 2d vectors (distance, angle) between x and each landmark in lm. 
  */
-vector<Vector2f> compute_range_bearing(Vector3f x, MatrixXf lm);
+vector<Vector2d> compute_range_bearing(Vector3d x, MatrixXd lm);
 
 /*!
     Finds all visible landmarks given current state.
@@ -50,6 +50,6 @@ vector<Vector2f> compute_range_bearing(Vector3f x, MatrixXf lm);
 
     @return Vector landmark indices which are visible.
  */
-vector<int> find2(vector<float> dx, vector<float> dy, float phi, float rmax);
+vector<int> find2(vector<double> dx, vector<double> dy, double phi, double rmax);
 
 #endif

--- a/cpp/core/line_plot_conversion.cpp
+++ b/cpp/core/line_plot_conversion.cpp
@@ -3,10 +3,10 @@
 
 using namespace std;
 
-MatrixXf line_plot_conversion(MatrixXf lnes)
+MatrixXd line_plot_conversion(MatrixXd lnes)
 {
 	int len = lnes.cols()*3 -1;			
-	MatrixXf p(2,len);
+	MatrixXd p(2,len);
 
 	for (int j=0; j<len; j+=3) {
 		int k = floor((j+1)/3); //reverse of len calculation

--- a/cpp/core/line_plot_conversion.h
+++ b/cpp/core/line_plot_conversion.h
@@ -5,6 +5,6 @@
 
 using namespace Eigen;
 
-MatrixXf line_plot_conversion(MatrixXf lnes);
+MatrixXd line_plot_conversion(MatrixXd lnes);
 
 #endif //LINE_PLOT_CONVERSION_H

--- a/cpp/core/multivariate_gauss.cpp
+++ b/cpp/core/multivariate_gauss.cpp
@@ -10,20 +10,20 @@ using namespace std;
 
 //output: sample set
 
-VectorXf multivariate_gauss(VectorXf x, MatrixXf P, int n) 
+VectorXd multivariate_gauss(VectorXd x, MatrixXd P, int n) 
 {
 	int len = x.size();
 	//choleksy decomposition
-	MatrixXf S = P.llt().matrixL();
-	MatrixXf X(len,n);
+	MatrixXd S = P.llt().matrixL();
+	MatrixXd X(len,n);
 	
 
-    float LO = -1.0f;
-    float HI = 1.0f;
+    double LO = -1.0f;
+    double HI = 1.0f;
 
     for (int i = 0; i < len; i++) {
         for (int j=0; j< n; j++) {
-            float r3 = LO + (float)rand()/((float)RAND_MAX/(HI-LO));
+            double r3 = LO + (double)rand()/((double)RAND_MAX/(HI-LO));
             X(i,j) = r3;
         }
     }
@@ -31,7 +31,7 @@ VectorXf multivariate_gauss(VectorXf x, MatrixXf P, int n)
     //TODO: this does not work. Also fixed other instances of nRandMat	
 	//X = nRandMat::randn(len,n);	
 	
-	MatrixXf ones = MatrixXf::Ones(1,n);	
+	MatrixXd ones = MatrixXd::Ones(1,n);	
 	return S*X + x*ones;
 }
 

--- a/cpp/core/multivariate_gauss.h
+++ b/cpp/core/multivariate_gauss.h
@@ -12,7 +12,7 @@ using namespace Eigen;
     @param[in]  P        Covariance Matrix.
     @param[in]  n        Number of samples.
  */
-VectorXf multivariate_gauss(VectorXf x, MatrixXf P, int n);
+VectorXd multivariate_gauss(VectorXd x, MatrixXd P, int n);
 
 #endif //MULTIVARIATE_GAUSS_H
 

--- a/cpp/core/particle.cpp
+++ b/cpp/core/particle.cpp
@@ -77,12 +77,12 @@ void Particle::setPv(Matrix3d &Pv)
 	_Pv = Pv;
 }
 
-void Particle::setXd(vector<Vector2d> &xf)
+void Particle::setXf(vector<Vector2d> &xf)
 {
 	_xf = xf;
 }
 
-void Particle::setXdi(int i, Vector2d &vec) 
+void Particle::setXfi(int i, Vector2d &vec) 
 {
 	if (i >= _xf.size()){
 		_xf.resize(i+1);

--- a/cpp/core/particle.cpp
+++ b/cpp/core/particle.cpp
@@ -9,14 +9,14 @@
 Particle::Particle() 
 {
 	_w = 1.0; 
-	_xv = Vector3f(3);
+	_xv = Vector3d(3);
         _xv.setZero();
-	_Pv = Matrix3f(3,3);
+	_Pv = Matrix3d(3,3);
         _Pv.setZero();
 	_da = NULL;
 }
 
-Particle::Particle(float w, Vector3f &xv, Matrix3f &Pv, vector<Vector2f> &xf, vector<Matrix2f> &Pf, float* da)
+Particle::Particle(double w, Vector3d &xv, Matrix3d &Pv, vector<Vector2d> &xf, vector<Matrix2d> &Pf, double* da)
 {
 	_w = w;
 	_xv = xv;
@@ -31,58 +31,58 @@ Particle::~Particle()
 }
 
 //getters
-float Particle::w() const
+double Particle::w() const
 {
 	return _w;	
 }
 
-Vector3f Particle::xv() const
+Vector3d Particle::xv() const
 {
 	return _xv;	
 }
 
-Matrix3f Particle::Pv() const
+Matrix3d Particle::Pv() const
 {
 	return _Pv;	
 }
 
-vector<Vector2f> Particle::xf() const
+vector<Vector2d> Particle::xf() const
 {
 	return _xf;	
 }
 
-vector<Matrix2f> Particle::Pf() const
+vector<Matrix2d> Particle::Pf() const
 {
 	return _Pf;	
 }
 
-float* Particle::da() const
+double* Particle::da() const
 {
 	return _da;	
 }
 
 //setters
-void Particle::setW(float w)
+void Particle::setW(double w)
 {
 	_w = w;
 }
 
-void Particle::setXv(Vector3f &xv)
+void Particle::setXv(Vector3d &xv)
 {
 	_xv = xv;
 }
 
-void Particle::setPv(Matrix3f &Pv)
+void Particle::setPv(Matrix3d &Pv)
 {
 	_Pv = Pv;
 }
 
-void Particle::setXf(vector<Vector2f> &xf)
+void Particle::setXd(vector<Vector2d> &xf)
 {
 	_xf = xf;
 }
 
-void Particle::setXfi(int i, Vector2f &vec) 
+void Particle::setXdi(int i, Vector2d &vec) 
 {
 	if (i >= _xf.size()){
 		_xf.resize(i+1);
@@ -90,12 +90,12 @@ void Particle::setXfi(int i, Vector2f &vec)
 	_xf[i] = vec;
 }
 
-void Particle::setPf(vector<Matrix2f> &Pf)
+void Particle::setPf(vector<Matrix2d> &Pf)
 {
 	_Pf = Pf;
 }
 
-void Particle::setPfi(int i, Matrix2f &m) 
+void Particle::setPfi(int i, Matrix2d &m) 
 {
 	if(i >= _Pf.size()) {
 		_Pf.resize(i+1);
@@ -103,7 +103,7 @@ void Particle::setPfi(int i, Matrix2f &m)
 	_Pf[i] = m;
 }
 
-void Particle::setDa(float* da)
+void Particle::setDa(double* da)
 {
 	_da = da;
 }

--- a/cpp/core/particle.h
+++ b/cpp/core/particle.h
@@ -38,8 +38,8 @@ public:
 	void setW(double w);
 	void setXv(Vector3d &xv);
 	void setPv(Matrix3d &Pv);
-	void setXd(vector<Vector2d> &xf);
-	void setXdi(int i, Vector2d &vec);
+	void setXf(vector<Vector2d> &xf);
+	void setXfi(int i, Vector2d &vec);
 	void setPf(vector<Matrix2d> &Pf);
 	void setPfi(int i, Matrix2d &m);
 	void setDa(double* da);

--- a/cpp/core/particle.h
+++ b/cpp/core/particle.h
@@ -8,10 +8,10 @@ using namespace Eigen;
 using namespace std;
 
 namespace Eigen {
-	using Matrix13f = Matrix<float, 1, 3>;
-	using Matrix31f = Matrix<float, 3, 1>;
-	using Matrix23f = Matrix<float, 2, 3>;
-	using Matrix32f = Matrix<float, 3, 2>;
+	using Matrix13d = Matrix<double, 1, 3>;
+	using Matrix31d = Matrix<double, 3, 1>;
+	using Matrix23d = Matrix<double, 2, 3>;
+	using Matrix32d = Matrix<double, 3, 2>;
 }
 
 /*!
@@ -22,35 +22,35 @@ namespace Eigen {
 class Particle{
 public:
 	Particle();
-	Particle(float w, Vector3f &xv, Matrix3f &Pv, vector<Vector2f> &xf, vector<Matrix2f> &Pf, float* da);
+	Particle(double w, Vector3d &xv, Matrix3d &Pv, vector<Vector2d> &xf, vector<Matrix2d> &Pf, double* da);
 	~Particle();
         
 	//getters	
-	float w() const; ///< importance weight
-	Vector3f xv() const; ///< robot pose: x,y,theta (heading dir)
-	Matrix3f Pv() const; ///< control inputs, i.e. velocities
-	vector<Vector2f> xf() const; ///< 2d means of EKF
-	vector<Matrix2f> Pf() const; ///< covariance matrices for EKF 
+	double w() const; ///< importance weight
+	Vector3d xv() const; ///< robot pose: x,y,theta (heading dir)
+	Matrix3d Pv() const; ///< control inputs, i.e. velocities
+	vector<Vector2d> xf() const; ///< 2d means of EKF
+	vector<Matrix2d> Pf() const; ///< covariance matrices for EKF 
 															 ///< length is equal to seen landmarks at time t
-	float* da() const; ///< "Not sure, it's never used" (taken from readme)
+	double* da() const; ///< "Not sure, it's never used" (taken from readme)
 
 	//setters
-	void setW(float w);
-	void setXv(Vector3f &xv);
-	void setPv(Matrix3f &Pv);
-	void setXf(vector<Vector2f> &xf);
-	void setXfi(int i, Vector2f &vec);
-	void setPf(vector<Matrix2f> &Pf);
-	void setPfi(int i, Matrix2f &m);
-	void setDa(float* da);
+	void setW(double w);
+	void setXv(Vector3d &xv);
+	void setPv(Matrix3d &Pv);
+	void setXd(vector<Vector2d> &xf);
+	void setXdi(int i, Vector2d &vec);
+	void setPf(vector<Matrix2d> &Pf);
+	void setPfi(int i, Matrix2d &m);
+	void setDa(double* da);
 	
 private:
-	float _w;
-	Vector3f _xv;
-	Matrix3f _Pv;		
-	vector<Vector2f> _xf;
-	vector<Matrix2f> _Pf;
-	float* _da;
+	double _w;
+	Vector3d _xv;
+	Matrix3d _Pv;		
+	vector<Vector2d> _xf;
+	vector<Matrix2d> _Pf;
+	double* _da;
 };
 
 #endif //PARTICLES_H

--- a/cpp/core/pi_to_pi.cpp
+++ b/cpp/core/pi_to_pi.cpp
@@ -6,7 +6,7 @@
     Clips all angles in angle (radiants) to range [-pi,pi].
 	@param[out] angle   Vector of angles (radiants).
  */
-void pi_to_pi(VectorXf &angle) 
+void pi_to_pi(VectorXd &angle) 
 {
     int n;
     for (int i=0; i<angle.size(); i++) {
@@ -28,7 +28,7 @@ void pi_to_pi(VectorXf &angle)
     Clips ang  to range [-pi,pi].
 	@param[out] angle   angle in radiants.
  */
-float pi_to_pi(float ang) 
+double pi_to_pi(double ang) 
 {
     int n;
     if ((ang < (-2*pi)) || (ang > (2*pi))) {

--- a/cpp/core/pi_to_pi.h
+++ b/cpp/core/pi_to_pi.h
@@ -9,8 +9,8 @@
 using namespace Eigen;
 using namespace std;
 
-void pi_to_pi(VectorXf &angle); //takes in array of floats, returna array 
-float pi_to_pi(float ang);
-//vector<int> find1(VectorXf input);
+void pi_to_pi(VectorXd &angle); //takes in array of doubles, returna array 
+double pi_to_pi(double ang);
+//vector<int> find1(VectorXd input);
 
 #endif //PI_TO_PI_H

--- a/cpp/core/predict_true.cpp
+++ b/cpp/core/predict_true.cpp
@@ -1,7 +1,7 @@
 #include "predict_true.h"
 #include "pi_to_pi.h"
 
-void predict_true(Vector3f &xv, float V, float G, float WB, float dt) 
+void predict_true(Vector3d &xv, double V, double G, double WB, double dt) 
 {
 	xv(0) = xv(0) + V*dt*cos(G+xv(2));		
 	xv(1) = xv(1) + V*dt*sin(G+xv(2));

--- a/cpp/core/predict_true.h
+++ b/cpp/core/predict_true.h
@@ -13,6 +13,6 @@ using namespace Eigen;
     @param[in]  WB  Wheelbase.
     @param[in]  dt  timestep.
  */
-void predict_true(Vector3f &xv,float V,float G,float WB,float dt); 
+void predict_true(Vector3d &xv,double V,double G,double WB,double dt); 
 	
 #endif //PREDICT_TRUE_H

--- a/cpp/core/read_input_file.cpp
+++ b/cpp/core/read_input_file.cpp
@@ -6,7 +6,7 @@
  * Should have highest priority to be translated to C. Just make
  * the matrices a 2D array with fixed size for now.
  * **************************************************************************/
-void read_input_file(const string s, MatrixXf *lm, MatrixXf *wp) 
+void read_input_file(const string s, MatrixXd *lm, MatrixXd *wp) 
 {
 	using std::ifstream;
 	using std::istringstream;

--- a/cpp/core/read_input_file.h
+++ b/cpp/core/read_input_file.h
@@ -11,4 +11,4 @@
 using namespace Eigen;
 using namespace std;
 
-void read_input_file(const string s, MatrixXf *lm, MatrixXf *wp); 
+void read_input_file(const string s, MatrixXd *lm, MatrixXd *wp); 

--- a/cpp/core/resample_particles.cpp
+++ b/cpp/core/resample_particles.cpp
@@ -10,14 +10,14 @@ using namespace std;
 void resample_particles(vector<Particle> &particles, int Nmin, int doresample) 
 {
     int N = particles.size();
-    VectorXf w(N);
+    VectorXd w(N);
     w.setZero();
 
     for (int i=0; i<N; i++) {
         w(i) = particles[i].w();
     }
 
-    float ws = w.sum();
+    double ws = w.sum();
     assert(ws != 0);
 
     for (int i=0; i<N; i++) {
@@ -28,7 +28,7 @@ void resample_particles(vector<Particle> &particles, int Nmin, int doresample)
         particles[i].setW(particles[i].w()/ws);
     }
 
-    float Neff=0;
+    double Neff=0;
     vector<int> keep;
     stratified_resample(w,keep,Neff);
 
@@ -42,7 +42,7 @@ void resample_particles(vector<Particle> &particles, int Nmin, int doresample)
             particles[i] = old_particles[keep[i]]; 	
         }	
         for (int i=0; i<N; i++) {
-            float new_w = 1.0f/(float)N;
+            double new_w = 1.0f/(double)N;
             assert(isfinite(new_w));
             assert(N == 100);
             particles[i].setW(new_w);

--- a/cpp/core/stratified_random.cpp
+++ b/cpp/core/stratified_random.cpp
@@ -4,12 +4,12 @@
 
 using namespace std;
 
-void stratified_random(int N, vector<float> &di)
+void stratified_random(int N, vector<double> &di)
 { 
-    float k = 1.0/(float)N;
+    double k = 1.0/(double)N;
    
     //deterministic intervals
-    float temp = k/2;
+    double temp = k/2;
     di.push_back(temp);
     while (temp < 1-k/2) {
         temp = temp+k;
@@ -26,7 +26,7 @@ void stratified_random(int N, vector<float> &di)
     //assert(di.size() == N); 
     */
     //dither within interval
-    vector<float>::iterator diter; 
+    vector<double>::iterator diter; 
     for (diter = di.begin(); diter != di.end(); diter++) {
         *diter = (*diter) + unifRand() * k - (k/2);
     }

--- a/cpp/core/stratified_random.h
+++ b/cpp/core/stratified_random.h
@@ -12,7 +12,7 @@ using namespace std;
     @param[in]  N     Interval size (inverse).
 	@param[out] di    Generated array of random stratified numbers.
  */
-void stratified_random(int N, vector<float> &di);
+void stratified_random(int N, vector<double> &di);
 
 /*!
     Generates a random, uniformly sampled number between [0,1].

--- a/cpp/core/stratified_resample.cpp
+++ b/cpp/core/stratified_resample.cpp
@@ -4,17 +4,17 @@
 
 using namespace std;
 
-void stratified_resample(VectorXf w, vector<int> &keep, float &Neff)
+void stratified_resample(VectorXd w, vector<int> &keep, double &Neff)
 {
-    VectorXf wsqrd(w.size());
-    float wsum = w.sum();    
+    VectorXd wsqrd(w.size());
+    double wsum = w.sum();    
 
     for (int i=0; i<w.size(); i++) {
         w(i) = w(i)/ wsum;
-        wsqrd(i) = (float)pow(w(i),2);
+        wsqrd(i) = (double)pow(w(i),2);
     }
     
-    Neff = 1.0f/(float)wsqrd.sum();
+    Neff = 1.0f/(double)wsqrd.sum();
 
     int len = w.size();
     keep.resize(len);
@@ -22,7 +22,7 @@ void stratified_resample(VectorXf w, vector<int> &keep, float &Neff)
         keep[i] = -1;
     }
 
-    vector<float> select;
+    vector<double> select;
     stratified_random(len,select); 
     /*
     select.push_back(0.0948);
@@ -48,12 +48,12 @@ void stratified_resample(VectorXf w, vector<int> &keep, float &Neff)
 }
 
 
-void cumsum(VectorXf &w) 
+void cumsum(VectorXd &w) 
 {
-    VectorXf csumVec = VectorXf(w);
+    VectorXd csumVec = VectorXd(w);
 
     for (int i=0; i< w.size(); i++) {
-        float sum =0;
+        double sum =0;
         for (int j=0; j<=i; j++) {
 	    sum+=csumVec(j);
 	}			

--- a/cpp/core/stratified_resample.h
+++ b/cpp/core/stratified_resample.h
@@ -9,17 +9,17 @@ using namespace std;
 
 /*!
     Stratified resampling based on weights w. Interval size is len(w).
-    @param[in]   w          Eigen::VectorXf of weights.
+    @param[in]   w          Eigen::VectorXd of weights.
 	@param[out]  keep       Vector of ints that indicate whether w(i) should be kept or not.
     @param[out]  Neff       = 1/sum(w_i^2).
  */
-void stratified_resample(VectorXf w, vector<int> &keep, float &Neff);
+void stratified_resample(VectorXd w, vector<int> &keep, double &Neff);
 
 /*!
     Returns a vector of all weights below its index are summed up. 
     w_out(i) = sum_j=0->j=i-1(w_in(j))
-    @param[out] w   Eigen::VectorXf of weights.
+    @param[out] w   Eigen::VectorXd of weights.
  */
-void cumsum(VectorXf &w);
+void cumsum(VectorXd &w);
 
 #endif

--- a/cpp/fastslam1/compute_weight.cpp
+++ b/cpp/fastslam1/compute_weight.cpp
@@ -11,34 +11,34 @@ using namespace std;
 //
 //compute particle weight for sampling
 //
-float compute_weight(Particle &particle, vector<Vector2f> z, vector<int> idf,
-	Matrix2f R) 
+double compute_weight(Particle &particle, vector<Vector2d> z, vector<int> idf,
+	Matrix2d R) 
 {
-    vector<Matrix23f> Hv;
-    vector<Matrix2f> Hf;
-    vector<Matrix2f> Sf;
-    vector<Vector2f> zp;     
+    vector<Matrix23d> Hv;
+    vector<Matrix2d> Hf;
+    vector<Matrix2d> Sf;
+    vector<Vector2d> zp;     
 
     //process each feature, incrementally refine proposal distribution
     compute_jacobians(particle,idf,R,zp,&Hv,&Hf,&Sf);
 
-    vector<Vector2f> v;
+    vector<Vector2d> v;
     for (int j =0; j<z.size(); j++) {
-	Vector2f v_j = z[j] - zp[j];
+	Vector2d v_j = z[j] - zp[j];
 	v_j[1] = pi_to_pi(v_j[1]);
 	v.push_back(v_j);
     }
 
 
-    float w = 1.0f;
+    double w = 1.0f;
 
-    Matrix2f S;
-    float den, num;
+    Matrix2d S;
+    double den, num;
     for (int i=0; i<z.size(); i++) {
 	S = Sf[i];
 	den = 2*pi*sqrt(S.determinant());
 	num = std::exp(-0.5 * v[i].transpose() * S.inverse() * v[i]);
-	w *= (float)num/(float) den; 
+	w *= (double)num/(double) den; 
     }
 
     return w;

--- a/cpp/fastslam1/compute_weight.h
+++ b/cpp/fastslam1/compute_weight.h
@@ -8,6 +8,6 @@
 using namespace Eigen;
 using namespace std;
 
-float compute_weight(Particle &particle, vector<Vector2f> z, vector<int> idf, Matrix2f R); 
+double compute_weight(Particle &particle, vector<Vector2d> z, vector<int> idf, Matrix2d R); 
 
 #endif

--- a/cpp/fastslam1/fastslam1_sim.cpp
+++ b/cpp/fastslam1/fastslam1_sim.cpp
@@ -19,7 +19,7 @@ using namespace config;
 using namespace std;
 
 int counter=0;
-vector<Particle> fastslam1_sim(MatrixXf lm, MatrixXf wp) 
+vector<Particle> fastslam1_sim(MatrixXd lm, MatrixXd wp) 
 {
     if (SWITCH_PREDICT_NOISE) {
 	printf("Sampling from predict noise usually OFF for FastSLAM 2.0\n");	
@@ -32,7 +32,7 @@ vector<Particle> fastslam1_sim(MatrixXf lm, MatrixXf wp)
     R << sigmaR*sigmaR, 0, 
       0, sigmaB*sigmaB;
 
-    float veh[2][3] = {{0,-WHEELBASE,-WHEELBASE},{0,-1,1}};
+    double veh[2][3] = {{0,-WHEELBASE,-WHEELBASE},{0,-1,1}};
 
     //vector of particles (their count will change)
     vector<Particle> particles(NPARTICLES);
@@ -41,16 +41,16 @@ vector<Particle> fastslam1_sim(MatrixXf lm, MatrixXf wp)
     }
 
     //initialize particle weights as uniform
-    float uniformw = 1.0/(float)NPARTICLES;    
+    double uniformw = 1.0/(double)NPARTICLES;    
     for (unsigned int p = 0; p < NPARTICLES; p++) {
 	particles[p].setW(uniformw);
     }
 
-    Vector3f xtrue(3);
+    Vector3d xtrue(3);
     xtrue.setZero();
 
-    float dt = DT_CONTROLS; //change in time btw predicts
-    float dtsum = 0; //change in time since last observation
+    double dt = DT_CONTROLS; //change in time btw predicts
+    double dtsum = 0; //change in time since last observation
 
     vector<int> ftag; //identifier for each landmark
     for (int i=0; i< lm.cols(); i++) {
@@ -58,21 +58,21 @@ vector<Particle> fastslam1_sim(MatrixXf lm, MatrixXf wp)
     }
 
     //data ssociation table
-    VectorXf da_table(lm.cols());
+    VectorXd da_table(lm.cols());
     for (int s=0; s<da_table.size(); s++) {
 	da_table[s] = -1;
     }
 
     int iwp = 0; //index to first waypoint
-    float G = 0; //initial steer angle
-    MatrixXf plines; //will later change to list of points
+    double G = 0; //initial steer angle
+    MatrixXd plines; //will later change to list of points
 
     if (SWITCH_SEED_RANDOM !=0) {
 	srand(SWITCH_SEED_RANDOM);
     } 		
 
-    Matrix2f Qe = Matrix2f(Q);
-    Matrix2f Re = Matrix2f(R);
+    Matrix2d Qe = Matrix2d(Q);
+    Matrix2d Re = Matrix2d(R);
 
     if (SWITCH_INFLATE_NOISE ==1) {
 	Qe = 2*Q;
@@ -80,7 +80,7 @@ vector<Particle> fastslam1_sim(MatrixXf lm, MatrixXf wp)
     }
 
     vector<int> ftag_visible;
-    vector<Vector2f> z; //range and bearings of visible landmarks
+    vector<Vector2d> z; //range and bearings of visible landmarks
 
     //Main loop
     while (iwp !=-1) {
@@ -92,19 +92,19 @@ vector<Particle> fastslam1_sim(MatrixXf lm, MatrixXf wp)
 	predict_true(xtrue,V,G,WHEELBASE,dt);
 
 	//add process noise
-	float* VnGn = new float[2];        
+	double* VnGn = new double[2];        
 	add_control_noise(V,G,Q,SWITCH_CONTROL_NOISE,VnGn);
-	float Vn = VnGn[0];
-	float Gn = VnGn[1];
+	double Vn = VnGn[0];
+	double Gn = VnGn[1];
 
 	//Predict step	
 	for (unsigned int i=0; i< NPARTICLES; i++) {
 	    predict(particles[i],Vn,Gn,Qe,WHEELBASE,dt,SWITCH_PREDICT_NOISE);
 	    /* if (SWITCH_HEADING_KNOWN) { */
 		/* for (int j=0; j< particles[i].xf().size(); j++) { */
-		    /* Vector2f xf_j = particles[i].xf()[j]; */
+		    /* Vector2d xf_j = particles[i].xf()[j]; */
 		    /* xf_j[2] = xtrue[2]; */
-		    /* particles[i].setXfi(j,xf_j); */	
+		    /* particles[i].setXdi(j,xf_j); */	
 		/* } */           
 	    /* } */
 	}
@@ -128,8 +128,8 @@ vector<Particle> fastslam1_sim(MatrixXf lm, MatrixXf wp)
 	    //Compute (known) data associations
 	    int Nf = particles[0].xf().size();
 	    vector<int> idf;
-	    vector<Vector2f> zf;
-	    vector<Vector2f> zn;            
+	    vector<Vector2d> zf;
+	    vector<Vector2d> zn;            
 
 	    bool testflag= false;
 	    data_associate_known(z,ftag_visible,da_table,Nf,zf,idf,zn);
@@ -137,7 +137,7 @@ vector<Particle> fastslam1_sim(MatrixXf lm, MatrixXf wp)
 	    //perform update
 	    for (int i =0; i<NPARTICLES; i++) {
 		if (!zf.empty()) { //observe map features
-		    float w = compute_weight(particles[i],zf,idf,R);
+		    double w = compute_weight(particles[i],zf,idf,R);
 		    w = particles[i].w()*w;
 		    particles[i].setW(w);
 		    feature_update(particles[i],zf,idf,R);
@@ -160,16 +160,16 @@ vector<Particle> fastslam1_sim(MatrixXf lm, MatrixXf wp)
 
 //rb is measurements
 //xv is robot pose
-MatrixXf make_laser_lines(vector<Vector2f> rb, Vector3f xv) 
+MatrixXd make_laser_lines(vector<Vector2d> rb, Vector3d xv) 
 {
     if (rb.empty()) {
-	return MatrixXf(0,0);
+	return MatrixXd(0,0);
     }
 
     int len = rb.size();
-    MatrixXf lnes(4,len);
+    MatrixXd lnes(4,len);
 
-    MatrixXf globalMat(2,rb.size());
+    MatrixXd globalMat(2,rb.size());
     int j;
     for (j=0; j<globalMat.cols();j++) {
 	globalMat(0,j) = rb[j][0]*cos(rb[j][1]); 

--- a/cpp/fastslam1/fastslam1_sim.cpp
+++ b/cpp/fastslam1/fastslam1_sim.cpp
@@ -104,7 +104,7 @@ vector<Particle> fastslam1_sim(MatrixXd lm, MatrixXd wp)
 		/* for (int j=0; j< particles[i].xf().size(); j++) { */
 		    /* Vector2d xf_j = particles[i].xf()[j]; */
 		    /* xf_j[2] = xtrue[2]; */
-		    /* particles[i].setXdi(j,xf_j); */	
+		    /* particles[i].setXfi(j,xf_j); */	
 		/* } */           
 	    /* } */
 	}

--- a/cpp/fastslam1/fastslam1_sim.h
+++ b/cpp/fastslam1/fastslam1_sim.h
@@ -16,7 +16,7 @@
 using namespace std;
 using namespace Eigen;
 
-vector<Particle> fastslam1_sim(MatrixXf lm, MatrixXf wp);
-MatrixXf make_laser_lines(vector<Vector2f> rb, Vector3f xv);
+vector<Particle> fastslam1_sim(MatrixXd lm, MatrixXd wp);
+MatrixXd make_laser_lines(vector<Vector2d> rb, Vector3d xv);
 
 #endif //FASTSLAM2_SIM_H

--- a/cpp/fastslam1/main.cpp
+++ b/cpp/fastslam1/main.cpp
@@ -10,8 +10,8 @@ int main (int argc, char *argv[])
 {
 	MyTimer Timer = MyTimer();
 	Timer.Start();
-	MatrixXf lm; //landmark positions
-	MatrixXf wp; //way points
+	MatrixXd lm; //landmark positions
+	MatrixXd wp; //way points
 
 	if (argc < 2)
 		return -1;

--- a/cpp/fastslam1/predict.cpp
+++ b/cpp/fastslam1/predict.cpp
@@ -6,29 +6,29 @@
 
 using namespace std;
 
-void predict(Particle &particle,float V,float G,Matrix2f Q, float WB,float dt, int addrandom)
+void predict(Particle &particle,double V,double G,Matrix2d Q, double WB,double dt, int addrandom)
 {
 	//optional: add random noise to predicted state
 	if (addrandom ==1) {
-		Vector2f A(2);
+		Vector2d A(2);
 		A(0) = V;
 		A(1) = G;
-		Vector2f VG(2);
+		Vector2d VG(2);
 		VG = multivariate_gauss(A,Q,1);	
 		V = VG(0);
 		G = VG(1);	
 	}	
 
 	//predict state
-	Vector3f xv = particle.xv();
-	Vector3f xv_temp(3);
+	Vector3d xv = particle.xv();
+	Vector3d xv_temp(3);
 	xv_temp << xv(0) + V*dt*cos(G+xv(2)),
 			xv(1) + V*dt*sin(G+xv(2)),
 			pi_to_pi2(xv(2) + V*dt*sin(G/WB));
 	particle.setXv(xv_temp);
 }
 
-float pi_to_pi2(float ang) 
+double pi_to_pi2(double ang) 
 {
 	if (ang > pi) {
 		ang = ang - (2*pi);

--- a/cpp/fastslam1/predict.h
+++ b/cpp/fastslam1/predict.h
@@ -7,7 +7,7 @@
 
 using namespace Eigen;
 
-void predict(Particle &particle,float V,float G,Matrix2f Q, float WB,float dt, int addrandom);
-float pi_to_pi2(float ang); 
+void predict(Particle &particle,double V,double G,Matrix2d Q, double WB,double dt, int addrandom);
+double pi_to_pi2(double ang); 
 
 #endif //PREDICT_H

--- a/cpp/fastslam2/fastslam2_sim.cpp
+++ b/cpp/fastslam2/fastslam2_sim.cpp
@@ -20,7 +20,7 @@
 using namespace config;
 using namespace std;
 
-vector<Particle> fastslam2_sim(MatrixXf lm, MatrixXf wp) 
+vector<Particle> fastslam2_sim(MatrixXd lm, MatrixXd wp) 
 {
     if (SWITCH_PREDICT_NOISE) {
 	printf("Sampling from predict noise usually OFF for FastSLAM 2.0\n");	
@@ -35,7 +35,7 @@ vector<Particle> fastslam2_sim(MatrixXf lm, MatrixXf wp)
     R << sigmaR*sigmaR, 0, 
       0, sigmaB*sigmaB;
 
-    float veh[2][3] = {{0,-WHEELBASE,-WHEELBASE},{0,-1,1}};
+    double veh[2][3] = {{0,-WHEELBASE,-WHEELBASE},{0,-1,1}};
 
     //vector of particles (their count will change)
     vector<Particle> particles(NPARTICLES);
@@ -44,16 +44,16 @@ vector<Particle> fastslam2_sim(MatrixXf lm, MatrixXf wp)
     }
 
     //initialize particle weights as uniform
-    float uniformw = 1.0/(float)NPARTICLES;    
+    double uniformw = 1.0/(double)NPARTICLES;    
     for (unsigned int p = 0; p < NPARTICLES; p++) {
 	particles[p].setW(uniformw);
     }
 
-    Vector3f xtrue(3);
+    Vector3d xtrue(3);
     xtrue.setZero();
 
-    float dt = DT_CONTROLS; //change in time btw predicts
-    float dtsum = 0; //change in time since last observation
+    double dt = DT_CONTROLS; //change in time btw predicts
+    double dtsum = 0; //change in time since last observation
 
     vector<int> ftag; //identifier for each landmark
     for (int i=0; i< lm.cols(); i++) {
@@ -61,20 +61,20 @@ vector<Particle> fastslam2_sim(MatrixXf lm, MatrixXf wp)
     }
 
     //data association table
-    VectorXf da_table(lm.cols());
+    VectorXd da_table(lm.cols());
     for (int s=0; s<da_table.size(); s++) {
 	da_table[s] = -1;
     }
 
     int iwp = 0; //index to first waypoint
-    float G = 0; //initial steer angle
+    double G = 0; //initial steer angle
 
     //if (SWITCH_SEED_RANDOM !=0) {
 	//srand(SWITCH_SEED_RANDOM);
     //} 		
 
-    MatrixXf Qe = MatrixXf(Q);
-    MatrixXf Re = MatrixXf(R);
+    MatrixXd Qe = MatrixXd(Q);
+    MatrixXd Re = MatrixXd(R);
 
     if (SWITCH_INFLATE_NOISE ==1) {
 	Qe = 2*Q;
@@ -82,7 +82,7 @@ vector<Particle> fastslam2_sim(MatrixXf lm, MatrixXf wp)
     }
 
     vector<int> ftag_visible;
-    vector<Vector2f> z;
+    vector<Vector2d> z;
 
     //Main loop
     while (iwp !=-1) {
@@ -94,10 +94,10 @@ vector<Particle> fastslam2_sim(MatrixXf lm, MatrixXf wp)
 	predict_true(xtrue,V,G,WHEELBASE,dt);
 
 	//add process noise
-	float* VnGn = new float[2];
+	double* VnGn = new double[2];
 	add_control_noise(V,G,Q,SWITCH_CONTROL_NOISE,VnGn);
-	float Vn = VnGn[0];
-	float Gn = VnGn[1];
+	double Vn = VnGn[0];
+	double Gn = VnGn[1];
 
 	//Predict step	
 	for (unsigned int i=0; i< NPARTICLES; i++) {
@@ -122,8 +122,8 @@ vector<Particle> fastslam2_sim(MatrixXf lm, MatrixXf wp)
 	    //Compute (known) data associations
 	    int Nf = particles[0].xf().size();
 	    vector<int> idf;
-	    vector<Vector2f> zf;
-	    vector<Vector2f> zn;
+	    vector<Vector2d> zf;
+	    vector<Vector2d> zn;
 
 	    bool testflag= false;
 	    data_associate_known(z,ftag_visible,da_table,Nf,zf,idf,zn);
@@ -152,12 +152,12 @@ vector<Particle> fastslam2_sim(MatrixXf lm, MatrixXf wp)
 	    if (!zn.empty()) {
 		for (unsigned i=0; i<NPARTICLES; i++) {
 		    if (zf.empty()) { //sample from proposal distribution if we have not already done so above
-			Vector3f xv = multivariate_gauss(particles[i].xv(),
+			Vector3d xv = multivariate_gauss(particles[i].xv(),
 				particles[i].Pv(),1);
 
 			assert(isfinite(particles[i].w()));
 			particles[i].setXv(xv);
-			Matrix3f pv(3,3); 
+			Matrix3d pv(3,3); 
 			pv.setZero();
 			particles[i].setPv(pv); 
 		    }

--- a/cpp/fastslam2/fastslam2_sim.h
+++ b/cpp/fastslam2/fastslam2_sim.h
@@ -16,7 +16,7 @@
 using namespace std;
 using namespace Eigen;
 
-vector<Particle> fastslam2_sim(MatrixXf lm, MatrixXf wp);
-//MatrixXf make_laser_lines(vector<VectorXf> rb, VectorXf xv);
+vector<Particle> fastslam2_sim(MatrixXd lm, MatrixXd wp);
+//MatrixXd make_laser_lines(vector<VectorXd> rb, VectorXd xv);
 
 #endif //FASTSLAM2_SIM_H

--- a/cpp/fastslam2/gauss_evaluate.cpp
+++ b/cpp/fastslam2/gauss_evaluate.cpp
@@ -7,27 +7,27 @@
 using namespace std; 
 
 //approximation of the desired sampling distribution. 
-float gauss_evaluate(VectorXf v, MatrixXf S, int logflag) 
+double gauss_evaluate(VectorXd v, MatrixXd S, int logflag) 
 {
     int D = v.size();    
-    MatrixXf Sc = S.llt().matrixL();
+    MatrixXd Sc = S.llt().matrixL();
 
     //normalised innovation
-    VectorXf ni = Sc.jacobiSvd(ComputeThinU | ComputeThinV).solve(v);
+    VectorXd ni = Sc.jacobiSvd(ComputeThinU | ComputeThinV).solve(v);
 
-    float E=0.f;
-    VectorXf nin(ni.size());
+    double E=0.f;
+    VectorXd nin(ni.size());
     for (int s=0; s< ni.size(); s++) {
         nin[s] = ni[s]*ni[s];
     }
     E = -0.5f * nin.sum();
 
     int i,j;
-    float C,w;
+    double C,w;
     unsigned  m = min(Sc.rows(), Sc.cols());
 
     if (logflag !=1) {
-        float prod = 1;
+        double prod = 1;
         for (i=0; i<Sc.rows(); i++) {
             for (j=0; j<Sc.cols(); j++) {
                 if (i==j) {
@@ -39,7 +39,7 @@ float gauss_evaluate(VectorXf v, MatrixXf S, int logflag)
         w = exp(E)/C; //likelihood (exp(E) is targe distribution).
         //C is the proposal distribution
     } else {
-        float sum=0;
+        double sum=0;
         for (i=0; i<m; i++) {
             sum+=log(Sc(i,i)); 
         }

--- a/cpp/fastslam2/gauss_evaluate.h
+++ b/cpp/fastslam2/gauss_evaluate.h
@@ -5,7 +5,7 @@
 
 using namespace Eigen;
 
-float gauss_evaluate(VectorXf v, MatrixXf S, int logflag);
+double gauss_evaluate(VectorXd v, MatrixXd S, int logflag);
 
 /*
 **INPUTS:

--- a/cpp/fastslam2/main.cpp
+++ b/cpp/fastslam2/main.cpp
@@ -11,8 +11,8 @@ int main (int argc, char *argv[])
 	MyTimer Timer = MyTimer();
 	Timer.Start();
 
-	MatrixXf lm; //landmark positions
-	MatrixXf wp; //way points
+	MatrixXd lm; //landmark positions
+	MatrixXd wp; //way points
 
 	if (argc < 2)
 		return -1;

--- a/cpp/fastslam2/observe_heading.cpp
+++ b/cpp/fastslam2/observe_heading.cpp
@@ -9,23 +9,23 @@
 
 using namespace std;
 
-void observe_heading(Particle &particle, float phi, int useheading) 
+void observe_heading(Particle &particle, double phi, int useheading) 
 {
     if (useheading ==0){
     	return;
     }
-    float sigmaPhi = 0.01*pi/180.0; 
+    double sigmaPhi = 0.01*pi/180.0; 
     //cout<<"sigmaPhi "<<sigmaPhi<<endl;	
-    Vector3f xv = particle.xv();
+    Vector3d xv = particle.xv();
     //cout<<"xv"<<endl;
     //cout<<xv<<endl;		
-    Matrix3f Pv = particle.Pv();
+    Matrix3d Pv = particle.Pv();
     //cout<<"Pv"<<endl;
     //cout<<Pv<<endl;    
-    Matrix13f H(1,3);
+    Matrix13d H(1,3);
     H<<0,0,1;            
 
-    float v = pi_to_pi(phi-xv(2));
+    double v = pi_to_pi(phi-xv(2));
     //cout<<"v"<<endl;
     //cout<<v<<endl;
     KF_joseph_update(xv,Pv,v,pow(sigmaPhi,2),H);

--- a/cpp/fastslam2/observe_heading.h
+++ b/cpp/fastslam2/observe_heading.h
@@ -4,6 +4,6 @@
 #include<Eigen/Dense>
 #include "core/particle.h"
 
-void observe_heading(Particle &particle, float phi, int useheading);
+void observe_heading(Particle &particle, double phi, int useheading);
 
 #endif

--- a/cpp/fastslam2/predict.cpp
+++ b/cpp/fastslam2/predict.cpp
@@ -8,10 +8,10 @@
 
 using namespace std;
 
-void predict(Particle &particle,float V,float G,Matrix2f Q, float WB,float dt, int addrandom)
+void predict(Particle &particle,double V,double G,Matrix2d Q, double WB,double dt, int addrandom)
 {
-	VectorXf xv = particle.xv();
-        MatrixXf Pv = particle.Pv();
+	VectorXd xv = particle.xv();
+        MatrixXd Pv = particle.Pv();
         #if 0
         cout<<"particle.xv() in predict"<<endl;
         cout<<particle.xv()<<endl;
@@ -19,19 +19,19 @@ void predict(Particle &particle,float V,float G,Matrix2f Q, float WB,float dt, i
         cout<<particle.Pv()<<endl;
 	#endif
         //Jacobians
-	float phi = xv(2);
-	MatrixXf Gv(3,3); 
+	double phi = xv(2);
+	MatrixXd Gv(3,3); 
 
 	Gv << 1,0,-V*dt*sin(G+phi),
 	       0,1,V*dt*cos(G+phi),
 	       0,0,1;
-	MatrixXf Gu(3,2); 
+	MatrixXd Gu(3,2); 
 	Gu << dt*cos(G+phi), -V*dt*sin(G+phi),
 		dt*sin(G+phi), V*dt*cos(G+phi),
 		dt*sin(G)/WB, V*dt*cos(G)/WB;
 
 	//predict covariance
-	Matrix3f newPv;//(Pv.rows(),Pv.cols());
+	Matrix3d newPv;//(Pv.rows(),Pv.cols());
         
         //TODO: Pv here is somehow corrupted. Probably in sample_proposal
         #if 0
@@ -44,24 +44,24 @@ void predict(Particle &particle,float V,float G,Matrix2f Q, float WB,float dt, i
 
 	//optional: add random noise to predicted state
 	if (addrandom ==1) {
-		VectorXf A(2);
+		VectorXd A(2);
 		A(0) = V;
 		A(1) = G;
-		VectorXf VG(2);
+		VectorXd VG(2);
 		VG = multivariate_gauss(A,Q,1);	
 		V = VG(0);
 		G = VG(1);	
 	}	
 
 	//predict state
-	Vector3f xv_temp(3);
+	Vector3d xv_temp(3);
         xv_temp << xv(0) + V*dt*cos(G+xv(2)),
 	           xv(1) + V*dt*sin(G+xv(2)),
 	           pi_to_pi2(xv(2) + V*dt*sin(G/WB));
         particle.setXv(xv_temp);
 }
 
-float pi_to_pi2(float ang) 
+double pi_to_pi2(double ang) 
 {
     if (ang > pi) {
         ang = ang - (2*pi);

--- a/cpp/fastslam2/predict.h
+++ b/cpp/fastslam2/predict.h
@@ -7,8 +7,8 @@
 
 using namespace Eigen;
 
-void predict(Particle &particle,float V,float G,Matrix2f Q, float WB,float dt, int addrandom);
+void predict(Particle &particle,double V,double G,Matrix2d Q, double WB,double dt, int addrandom);
 
-float pi_to_pi2(float ang); 
+double pi_to_pi2(double ang); 
 
 #endif //PREDICT_H

--- a/cpp/fastslam2/sample_proposal.cpp
+++ b/cpp/fastslam2/sample_proposal.cpp
@@ -6,24 +6,24 @@
 #include "assert.h"
 
 //compute proposal distribution, then sample from it, and compute new particle weight
-void sample_proposal(Particle &particle, vector<Vector2f> z, vector<int> idf, Matrix2f R)
+void sample_proposal(Particle &particle, vector<Vector2d> z, vector<int> idf, Matrix2d R)
 {
     assert(isfinite(particle.w()));
-    Vector3f xv = Vector3f(particle.xv()); //robot position
-    Matrix3f Pv = Matrix3f(particle.Pv()); //controls (motion command)
+    Vector3d xv = Vector3d(particle.xv()); //robot position
+    Matrix3d Pv = Matrix3d(particle.Pv()); //controls (motion command)
 
-    Vector3f xv0 = Vector3f(xv);
-    Matrix3f Pv0 = Matrix3f(Pv);	
+    Vector3d xv0 = Vector3d(xv);
+    Matrix3d Pv0 = Matrix3d(Pv);	
 
-    vector<Matrix23f> Hv;
-    vector<Matrix2f> Hf;
-    vector<Matrix2f> Sf;
-    vector<Vector2f> zp;
+    vector<Matrix23d> Hv;
+    vector<Matrix2d> Hf;
+    vector<Matrix2d> Sf;
+    vector<Vector2d> zp;
 
-    Vector2f zpi;
-    Matrix23f Hvi;
-    Matrix2f Hfi;
-    Matrix2f Sfi;
+    Vector2d zpi;
+    Matrix23d Hvi;
+    Matrix2d Hfi;
+    Matrix2d Sfi;
 
     //process each feature, incrementally refine proposal distribution
     unsigned i,r;
@@ -44,7 +44,7 @@ void sample_proposal(Particle &particle, vector<Vector2f> z, vector<int> idf, Ma
         Hfi = Hf[0];
         Sfi = Sf[0];
 
-        Vector2f vi = z[i] - zpi;
+        Vector2d vi = z[i] - zpi;
         vi[1] = pi_to_pi(vi[1]);
 
         //proposal covariance
@@ -58,22 +58,22 @@ void sample_proposal(Particle &particle, vector<Vector2f> z, vector<int> idf, Ma
     }
 
     //sample from proposal distribution
-    Vector3f xvs = multivariate_gauss(xv,Pv,1); 
+    Vector3d xvs = multivariate_gauss(xv,Pv,1); 
     particle.setXv(xvs);
-    Matrix3f zeros(3,3);
+    Matrix3d zeros(3,3);
     zeros.setZero();
     particle.setPv(zeros);
 
     //compute sample weight: w = w* p(z|xk) p(xk|xk-1) / proposal
-    float like = likelihood_given_xv(particle, z, idf, R);
-    float prior = gauss_evaluate(delta_xv(xv0,xvs), Pv0,0);
-    float prop = gauss_evaluate(delta_xv(xv,xvs),Pv,0);
+    double like = likelihood_given_xv(particle, z, idf, R);
+    double prior = gauss_evaluate(delta_xv(xv0,xvs), Pv0,0);
+    double prop = gauss_evaluate(delta_xv(xv,xvs),Pv,0);
     assert(isfinite(particle.w()));
 
-    float a = prior/prop;
-    float b = particle.w() * a;
-    float newW = like * b;
-    //float newW = particle.w() * like * prior / prop;
+    double a = prior/prop;
+    double b = particle.w() * a;
+    double newW = like * b;
+    //double newW = particle.w() * like * prior / prop;
     #if 0
     if (!isfinite(newW)) {
 	cout<<"LIKELIHOOD GIVEN XV INPUTS"<<endl;   
@@ -135,14 +135,14 @@ void sample_proposal(Particle &particle, vector<Vector2f> z, vector<int> idf, Ma
     particle.setW(newW);
 } 
 
-float likelihood_given_xv(Particle particle, vector<Vector2f> z, vector<int>idf, Matrix2f R) 
+double likelihood_given_xv(Particle particle, vector<Vector2d> z, vector<int>idf, Matrix2d R) 
 {
-    float w = 1;
+    double w = 1;
 
-    vector<Matrix23f> Hv;
-    vector<Matrix2f> Hf;
-    vector<Matrix2f> Sf;
-    vector<Vector2f> zp;
+    vector<Matrix23d> Hv;
+    vector<Matrix2d> Hf;
+    vector<Matrix2d> Sf;
+    vector<Vector2d> zp;
 
     unsigned j,k;
     vector<int> idfi;
@@ -155,7 +155,7 @@ float likelihood_given_xv(Particle particle, vector<Vector2f> z, vector<int>idf,
 	Sf.clear();
 	zp.clear();
 
-	Vector2f v(z.size()); 
+	Vector2d v(z.size()); 
         compute_jacobians(particle,idfi,R,zp,&Hv,&Hf,&Sf);
 	v = z[j] - zp[0];
         v(1) = pi_to_pi(v(1));
@@ -164,10 +164,10 @@ float likelihood_given_xv(Particle particle, vector<Vector2f> z, vector<int>idf,
     return w;
 }
 
-Vector3f delta_xv(Vector3f xv1, Vector3f xv2)
+Vector3d delta_xv(Vector3d xv1, Vector3d xv2)
 {
     //compute innovation between two xv estimates, normalising the heading component
-    Vector3f dx = xv1-xv2; 
+    Vector3d dx = xv1-xv2; 
     dx(2) = pi_to_pi(dx(2));
     return dx;
 }

--- a/cpp/fastslam2/sample_proposal.h
+++ b/cpp/fastslam2/sample_proposal.h
@@ -13,9 +13,9 @@
 using namespace Eigen;
 using namespace std;
 
-void sample_proposal(Particle &particle, vector<Vector2f> z, vector<int> idf, Matrix2f R);
-//float likelihood_given_xv(Particle particle, MatrixXf z, vector<int>idf, MatrixXf R);
-float likelihood_given_xv(Particle particle, vector<Vector2f> z, vector<int>idf, Matrix2f R); 
-Vector3f delta_xv(Vector3f xv1, Vector3f xv2);
+void sample_proposal(Particle &particle, vector<Vector2d> z, vector<int> idf, Matrix2d R);
+//double likelihood_given_xv(Particle particle, MatrixXd z, vector<int>idf, MatrixXd R);
+double likelihood_given_xv(Particle particle, vector<Vector2d> z, vector<int>idf, Matrix2d R); 
+Vector3d delta_xv(Vector3d xv1, Vector3d xv2);
 
 #endif

--- a/cpp/gtest/TestFS1AgainstMatlab.cpp
+++ b/cpp/gtest/TestFS1AgainstMatlab.cpp
@@ -74,20 +74,20 @@ bool EqualVectors(vector<T> a, vector<T> b) {
 
 TEST(FASTSLAM_TEST,compute_steering_test)
 {
-    MatrixXf lm; //landmark positions
-    MatrixXf wp; //way points
+    MatrixXd lm; //landmark positions
+    MatrixXd wp; //way points
 
     read_input_file("example_webmap.mat", &lm, &wp);
 
-    VectorXf xtrue(3);
+    VectorXd xtrue(3);
     xtrue.setZero();
 
     int iwp =0;
-    float minD = 1;
-    float G = 0;
-    float rateG = 0.3491;
-    float maxG = 0.5236;
-    float dt = 0.0250;
+    double minD = 1;
+    double G = 0;
+    double rateG = 0.3491;
+    double maxG = 0.5236;
+    double dt = 0.0250;
 
     compute_steering(xtrue,wp,iwp,minD,G,rateG,maxG,dt);
 
@@ -97,54 +97,54 @@ TEST(FASTSLAM_TEST,compute_steering_test)
 
 TEST(FASTSLAM_TEST,predict_true_test)
 {
-    Vector3f xtrue(3);
+    Vector3d xtrue(3);
     xtrue.setZero();
 
-    float V = 3;
-    float G = -0.0087;
+    double V = 3;
+    double G = -0.0087;
     int WB = 4;
-    float dt = 0.0250;
+    double dt = 0.0250;
 
     predict_true(xtrue,V,G,WB,dt);
 
-    VectorXf xtrue_out(3);
+    VectorXd xtrue_out(3);
     xtrue_out<<0.0750,-0.0007,-0.0002;
 
     EXPECT_NE(xtrue,xtrue_out); 
 }
 
 TEST(FASTSLAM_TEST,add_control_noise_test) {
-    float V = 3;
-    float G = -0.0087;
-    Matrix2f Q;
+    double V = 3;
+    double G = -0.0087;
+    Matrix2d Q;
     Q   <<0.0900,0,
 	0,0.0027;
     int SWITCH_CONTROL_NOISE = 1;
-    float* VnGn = new float[2];
+    double* VnGn = new double[2];
     add_control_noise(V,G,Q,SWITCH_CONTROL_NOISE,VnGn);
 
-    float Vn = 2.6056;
-    float Gn = -0.0305;
+    double Vn = 2.6056;
+    double Gn = -0.0305;
     EXPECT_NE(VnGn[0],Vn);
     EXPECT_NE(VnGn[1],Gn);
 }
 
 TEST(FASTSLAM_TEST,predict_test){
-    float w = 0.01;
-    Vector3f xv(3);
+    double w = 0.01;
+    Vector3d xv(3);
     xv.setZero();
 
-    vector<Vector2f> xf;
-    vector<Matrix2f> Pf;
+    vector<Vector2d> xf;
+    vector<Matrix2d> Pf;
 
-    float Vn = 3.0194;
-    float Gn = 0.0227;
-    Matrix2f Qe(2,2);
+    double Vn = 3.0194;
+    double Gn = 0.0227;
+    Matrix2d Qe(2,2);
     Qe<< 0.0900, 0,
 	0,0.0027;
 
-    float WB = 4;
-    float dt = 0.0250;
+    double WB = 4;
+    double dt = 0.0250;
 
     int SWITCH_PREDICT_NOISE = 0;
 
@@ -157,11 +157,11 @@ TEST(FASTSLAM_TEST,predict_test){
     //predict
     predict(particle,Vn,Gn,Qe,WB,dt,SWITCH_PREDICT_NOISE);
 
-    float w_after = 0.01;
-    VectorXf xv_after(3);
+    double w_after = 0.01;
+    VectorXd xv_after(3);
     xv_after<<0.0755,0.0017,0.0004;
-    vector<VectorXf> xf_out;
-    vector<Matrix2f> Pf_out;
+    vector<VectorXd> xf_out;
+    vector<Matrix2d> Pf_out;
 
     //EXPECT_NE(w_after, particle.w());
     EXPECT_NE(xv_after[0], particle.xv()[0]);
@@ -174,10 +174,10 @@ TEST(FASTSLAM_TEST,predict_test){
 TEST(FASTSLAM_TEST,get_observations_test) 
 {
 
-    VectorXf xtrue(3);
+    VectorXd xtrue(3);
     xtrue<<0.6741,-0.0309,-0.0074;
-    MatrixXf lm; //landmark positions
-    MatrixXf wp; //way points
+    MatrixXd lm; //landmark positions
+    MatrixXd wp; //way points
 
     read_input_file("example_webmap.mat", &lm, &wp);
 
@@ -188,14 +188,14 @@ TEST(FASTSLAM_TEST,get_observations_test)
 
     vector<int> ftag_visible = vector<int>(ftag);
     EXPECT_EQ(ftag_visible.size(), ftag.size());    
-    float rmax = 30;
+    double rmax = 30;
 
-    vector<Vector2f> z_out = get_observations(xtrue,lm,ftag_visible,rmax);
-    vector<Vector2f> z_gt;
+    vector<Vector2d> z_out = get_observations(xtrue,lm,ftag_visible,rmax);
+    vector<Vector2d> z_gt;
 
-    VectorXf a(2);
+    VectorXd a(2);
     a<<25.7745,-1.4734;
-    VectorXf b(2);
+    VectorXd b(2);
     b<<25.2762, 0.1384;
     z_gt.push_back(a);
     z_gt.push_back(b);
@@ -210,15 +210,15 @@ TEST(FASTSLAM_TEST,get_observations_test)
 
 TEST(FASTSLAM_TEST,add_observation_noise_test)
 {
-    vector<Vector2f> z;
-    Vector2f a(2);
+    vector<Vector2d> z;
+    Vector2d a(2);
     a<<25.7745,-1.4734;
-    Vector2f b(2);
+    Vector2d b(2);
     b<<25.2762,0.1384;
     z.push_back(a);
     z.push_back(b);
 
-    Matrix2f R(2,2);
+    Matrix2d R(2,2);
     R<<0.0100, 0,
 	0, 0.0003;
 
@@ -226,10 +226,10 @@ TEST(FASTSLAM_TEST,add_observation_noise_test)
 
     add_observation_noise(z,R,SWITCH_SENSOR_NOISE);
 
-    vector<Vector2f> z_gt;
-    Vector2f a_gt(2);
+    vector<Vector2d> z_gt;
+    Vector2d a_gt(2);
     a_gt<<25.8522,-1.4621;
-    Vector2f b_gt(2);
+    Vector2d b_gt(2);
     b_gt<<25.3384,0.1309;
     z_gt.push_back(a_gt);
     z_gt.push_back(b_gt);
@@ -239,10 +239,10 @@ TEST(FASTSLAM_TEST,add_observation_noise_test)
 
 TEST(FASTSLAM_TEST,data_associate_known_test)
 {
-    vector<Vector2f> z;
-    Vector2f a(2);
+    vector<Vector2d> z;
+    Vector2d a(2);
     a<<25.7301,-1.4884;
-    Vector2f b(2);
+    Vector2d b(2);
     b<<25.1439,0.1137;
     z.push_back(a);
     z.push_back(b);
@@ -251,22 +251,22 @@ TEST(FASTSLAM_TEST,data_associate_known_test)
     ftag_visible.push_back(0);
     ftag_visible.push_back(21);
 
-    VectorXf da_table(35);
+    VectorXd da_table(35);
     for (int i=0; i<35; i++) {
 	da_table[i]=-1;
     }
 
     int Nf = 0;
 
-    vector<Vector2f> zf;
+    vector<Vector2d> zf;
     vector<int> idf;
-    vector<Vector2f> zn;
+    vector<Vector2d> zn;
     data_associate_known(z,ftag_visible,da_table, Nf,zf,idf,zn);
 
-    vector<Vector2f> zn_gt;
-    Vector2f c(2);
+    vector<Vector2d> zn_gt;
+    Vector2d c(2);
     c<<25.7301,-1.4884;
-    Vector2f d(2);
+    Vector2d d(2);
     d<<25.1439,0.1137;
     zn_gt.push_back(c);
     zn_gt.push_back(d);
@@ -275,7 +275,7 @@ TEST(FASTSLAM_TEST,data_associate_known_test)
     EXPECT_TRUE(zf.empty());
     EXPECT_TRUE(idf.empty());
 
-    VectorXf da_table_gt(35);
+    VectorXd da_table_gt(35);
     for (int i=0; i<35; i++) {
 	da_table_gt[i]=-1;
     }
@@ -289,33 +289,33 @@ TEST(FASTSLAM_TEST,data_associate_known_test)
 
 TEST(FASTSLAM_TEST,compute_jacobian_test)
 {
-    float w = 0.01;
+    double w = 0.01;
 
-    Vector3f xv(3);
+    Vector3d xv(3);
     xv << 1.3393, -0.1241, -0.0278;
 
-    vector<Vector2f> xf;
-    VectorXf a(2);
+    vector<Vector2d> xf;
+    VectorXd a(2);
     a<<3.4924 ,-25.7649;
-    VectorXf b(2);
+    VectorXd b(2);
     b<<25.6182,3.9462;
     xf.push_back(a);
     xf.push_back(b);
 
-    vector<Matrix2f> Pf;
-    Matrix2f c(2,2);
+    vector<Matrix2d> Pf;
+    Matrix2d c(2,2);
     c<< 0.2016,0.0210,
 	0.0210, 0.0123;
-    Matrix2f d(2,2);
+    Matrix2d d(2,2);
     d<< 0.0146, -0.0288,
 	-0.0288, 0.1898;
     Pf.push_back(c);
     Pf.push_back(d);
 
-    vector<Vector2f> zf;
-    Vector2f e(2);
+    vector<Vector2d> zf;
+    Vector2d e(2);
     e<<25.5817,-1.4737;
-    Vector2f f(2);
+    Vector2d f(2);
     f<<24.6040,0.1458;
     zf.push_back(e);
     zf.push_back(f);
@@ -324,7 +324,7 @@ TEST(FASTSLAM_TEST,compute_jacobian_test)
     idf.push_back(0);
     idf.push_back(1);
 
-    Matrix2f R(2,2);
+    Matrix2d R(2,2);
     R<< 0.0100, 0,
 	0, 0.0003;
 
@@ -335,47 +335,47 @@ TEST(FASTSLAM_TEST,compute_jacobian_test)
     particle.setXf(xf);
     particle.setPf(Pf);
 
-    vector<Vector2f> zp;
-    vector<Matrix23f> Hv;
-    vector<Matrix2f> Hf;
-    vector<Matrix2f> Sf;
+    vector<Vector2d> zp;
+    vector<Matrix23d> Hv;
+    vector<Matrix2d> Hf;
+    vector<Matrix2d> Sf;
     compute_jacobians(particle,idf,R,zp,&Hv,&Hf,&Sf);
 
     //compute jacobians
-    vector<Vector2f> zp_gt;
-    Vector2f g(2);
+    vector<Vector2d> zp_gt;
+    Vector2d g(2);
     g<<25.7310,-1.4593;
-    Vector2f h(2);
+    Vector2d h(2);
     f<<24.6177,0.1939;
     zp_gt.push_back(g);
     zp_gt.push_back(f);
 
-    vector<Matrix23f> Hv_gt;
-    Matrix23f i(2,3);
+    vector<Matrix23d> Hv_gt;
+    Matrix23d i(2,3);
     i<<-0.0837,0.9965,0,
 	-0.0387,-0.0033,-1.0;
-    Matrix23f j(2,3);
+    Matrix23d j(2,3);
     j<< -0.9862,-0.1653,0,
 	0.0067,-0.0401,-1.0;
     Hv_gt.push_back(i);
     Hv_gt.push_back(j);
 
-    vector<Matrix2f> Hf_gt;
-    Matrix2f m(2,2);
+    vector<Matrix2d> Hf_gt;
+    Matrix2d m(2,2);
     m<<0.0837,-0.9965,
 	0.0387, 0.0033;
-    Matrix2f n(2,2);
+    Matrix2d n(2,2);
     n<<0.9862, 0.1653,
 	-0.0067, 0.0401;
     Hf_gt.push_back(m);
     Hf_gt.push_back(n);
 
 
-    vector<MatrixXf> Sf_gt;
-    MatrixXf k(2,2);
+    vector<MatrixXd> Sf_gt;
+    MatrixXd k(2,2);
     k<< 0.0201, -0.0002,
 	-0.0002, 0.0006;
-    MatrixXf l(2,2);
+    MatrixXd l(2,2);
     l<< 0.0200, 0.0001, 
 	0.0001, 0.0006;
     Sf_gt.push_back(k);
@@ -391,27 +391,27 @@ TEST(FASTSLAM_TEST,compute_jacobian_test)
 TEST(FASTSLAM_TEST,compute_weight_test)
 {
     //w
-    float w = 0.01;
+    double w = 0.01;
 
     //xv
-    Vector3f xv(3);
+    Vector3d xv(3);
     xv << 1.2746 ,-0.1712 ,-0.0380;
 
     //xf
-    vector<Vector2f> xf;
-    VectorXf a(2);
+    vector<Vector2d> xf;
+    VectorXd a(2);
     a<<3.7387,-25.7130;
-    VectorXf b(2);
+    VectorXd b(2);
     b<<25.9565,2.8205;
     xf.push_back(a);
     xf.push_back(b);
 
     //Pf
-    vector<Matrix2f> Pf;
-    Matrix2f c(2,2);
+    vector<Matrix2d> Pf;
+    Matrix2d c(2,2);
     c<<0.2005, 0.0230,
 	0.0230,0.0128;
-    Matrix2f d(2,2);
+    Matrix2d d(2,2);
     d<<0.0124, -0.0211,
 	-0.0211,0.1953;
     Pf.push_back(c);
@@ -425,10 +425,10 @@ TEST(FASTSLAM_TEST,compute_weight_test)
     particle.setPf(Pf);
 
     //zf
-    vector<Vector2f> zf;
-    Vector2f e(2);
+    vector<Vector2d> zf;
+    Vector2d e(2);
     e<<25.6975,-1.4795;
-    Vector2f f(2);
+    Vector2d f(2);
     f<<24.5414,0.1713;
     zf.push_back(e);
     zf.push_back(f);
@@ -439,39 +439,39 @@ TEST(FASTSLAM_TEST,compute_weight_test)
     idf.push_back(1);
 
     //R
-    Matrix2f R(2,2);
+    Matrix2d R(2,2);
     R<< 0.0100, 0,
 	0, 0.0003;
 
-    float w_out = compute_weight(particle, zf,idf,R);
-    float w_gt = 29.6451;
+    double w_out = compute_weight(particle, zf,idf,R);
+    double w_gt = 29.6451;
     EXPECT_NE(w_out,w_gt);
 }
 
 TEST(FASTSLAM_TEST,feature_update_test)
 {
     //w
-    float w = 2.6993;
+    double w = 2.6993;
 
     //xv
-    Vector3f xv(3);
+    Vector3d xv(3);
     xv << 1.3010, -0.1420, -0.0315;
 
     //xf
-    vector<Vector2f> xf;
-    VectorXf a(2);
+    vector<Vector2d> xf;
+    VectorXd a(2);
     a<<2.7368,-25.5656;
-    VectorXf b(2);
+    VectorXd b(2);
     b<<25.9803,2.4939;
     xf.push_back(a);
     xf.push_back(b);
 
     //Pf
-    vector<Matrix2f> Pf;
-    Matrix2f c(2,2);
+    vector<Matrix2d> Pf;
+    Matrix2d c(2,2);
     c<<0.1983, 0.0155,
 	0.0155,0.0113;
-    Matrix2f d(2,2);
+    Matrix2d d(2,2);
     d<<0.0119, -0.0187,
 	-0.0187,0.1958;
     Pf.push_back(c);
@@ -485,10 +485,10 @@ TEST(FASTSLAM_TEST,feature_update_test)
     particle.setPf(Pf);
 
     //zf
-    vector<Vector2f> zf;
-    Vector2f e(2);
+    vector<Vector2d> zf;
+    Vector2d e(2);
     e<<25.4653,-1.4981;
-    Vector2f f(2);
+    Vector2d f(2);
     f<<24.6960,0.1803;
     zf.push_back(e);
     zf.push_back(f);   
@@ -499,7 +499,7 @@ TEST(FASTSLAM_TEST,feature_update_test)
     idf.push_back(1);
 
     //R
-    Matrix2f R(2,2);
+    Matrix2d R(2,2);
     R<< 0.0100, 0,
 	0, 0.0003;
 
@@ -507,27 +507,27 @@ TEST(FASTSLAM_TEST,feature_update_test)
     feature_update(particle,zf,idf,R);
 
     //w_gt
-    float w_gt = 2.6993;
+    double w_gt = 2.6993;
 
     //xv_gt
-    VectorXf xv_gt(3);
+    VectorXd xv_gt(3);
     xv_gt<< 1.3010, -0.1420, -0.0315;
 
     //xf_gt
-    vector<Vector2f> xf_gt;
-    VectorXf g(2);
+    vector<Vector2d> xf_gt;
+    VectorXd g(2);
     g<<2.5430,-25.5796;
-    VectorXf h(2);
+    VectorXd h(2);
     h<<25.8635,3.0197;
     xf_gt.push_back(g);
     xf_gt.push_back(h);
 
     //Pf_gt
-    vector<Matrix2f> Pf_gt;
-    Matrix2f i(2,2);
+    vector<Matrix2d> Pf_gt;
+    Matrix2d i(2,2);
     i<< 0.0985, 0.0065,
 	0.0065, 0.0055;
-    Matrix2f j(2,2);
+    Matrix2d j(2,2);
     j<< 0.0060, -0.0094,
 	-0.0094,0.0953;
     Pf_gt.push_back(i);
@@ -542,16 +542,16 @@ TEST(FASTSLAM_TEST,feature_update_test)
 
 TEST(FASTSLAM_TEST,add_feature_test)
 {
-    float w=0.0100;
+    double w=0.0100;
     //xv
-    Vector3f xv(3);
+    Vector3d xv(3);
     xv<<0.6981, -0.0280,-0.0067;
 
     //xf
-    vector<Vector2f> xf;
+    vector<Vector2d> xf;
 
     //Pf
-    vector<Matrix2f> Pf;
+    vector<Matrix2d> Pf;
 
     //particle
     Particle particle = Particle();
@@ -561,43 +561,43 @@ TEST(FASTSLAM_TEST,add_feature_test)
     particle.setPf(Pf);
 
     //zf
-    vector<Vector2f> zn;
-    Vector2f a(2);
+    vector<Vector2d> zn;
+    Vector2d a(2);
     a<<25.8047,-1.4638;
-    Vector2f b(2);
+    Vector2d b(2);
     b<<25.2023,0.1198;
     zn.push_back(a);
     zn.push_back(b);  
 
     //R
-    Matrix2f R(2,2);
+    Matrix2d R(2,2);
     R<< 0.0100, 0,
 	0, 0.0003;
 
     //add_feature
     add_feature(particle,zn,R);    
 
-    float w_out = 0.01;
+    double w_out = 0.01;
 
     //xv_out
-    VectorXf xv_out(3);
+    VectorXd xv_out(3);
     xv_out<<0.6981,-0.0280,-0.0067;
 
-    //Xf out
-    vector<VectorXf> xf_out;
-    VectorXf c(2);
+    //Xd out
+    vector<VectorXd> xf_out;
+    VectorXd c(2);
     c<<3.2830, -25.7030;
-    VectorXf d(2);
+    VectorXd d(2);
     d<< 25.7394, 2.8163;
     xf_out.push_back(c);
     xf_out.push_back(d);
 
     //Pf out 
-    vector<Matrix2f> Pf_out;
-    Matrix2f e(2,2);
+    vector<Matrix2d> Pf_out;
+    Matrix2d e(2,2);
     e<<0.2009, 0.0192,
 	0.0192,0.0119;
-    Matrix2f f(2,2);
+    Matrix2d f(2,2);
     f<<0.0123, -0.0206,
 	-0.0206, 0.1911;
     Pf_out.push_back(e);
@@ -612,10 +612,10 @@ TEST(FASTSLAM_TEST,add_feature_test)
 TEST(FASTSLAM_TEST, stratified_random_test) 
 {
     int N = 10;
-    vector<float> s;
+    vector<double> s;
     stratified_random(10, s);
 
-    vector<float> s_gt;
+    vector<double> s_gt;
     s_gt.push_back(0.0948);
     s_gt.push_back(0.1334);
     s_gt.push_back(0.2390);
@@ -646,9 +646,9 @@ TEST(FASTSLAM_TEST, stratified_random_test)
 TEST(FASTSLAM_TEST, stratified_resample_test) 
 {
     vector<int> keep;
-    float Neff;
+    double Neff;
 
-    VectorXf w(10);
+    VectorXd w(10);
     w<< 0.8074, 0.2651, 0.8959, 0.6080, 0.0144, 0.3440, 0.5337, 0.6278, 0.4467, 0.8111;
     stratified_resample(w, keep,Neff);
 
@@ -685,13 +685,13 @@ TEST(FASTSLAM_TEST, stratified_resample_test)
 /*
 TEST(FASTSLAM_TEST, fastslam1_sim_test)
 {
-    MatrixXf lm; //landmark positions
-    MatrixXf wp; //way points
+    MatrixXd lm; //landmark positions
+    MatrixXd wp; //way points
 
     read_input_file("example_webmap.mat", &lm, &wp);
 
     vector<Particle> p = fastslam1_sim(lm,wp);
-    VectorXf xv_gt;
+    VectorXd xv_gt;
     xv_gt<<-12.0425,-63.0278,1.1090;
     //EXPECT_NE(p[50].xv(),xv_gt);
     //EXPECT_NE(p[50].Pf[0],);   
@@ -701,33 +701,33 @@ TEST(FASTSLAM_TEST, fastslam1_sim_test)
 TEST(FASTSLAM_TEST, sample_proposal_test)
 {
     //w
-    float w = 0.01;
+    double w = 0.01;
 
     //xv
-    Vector3f xv(3);
+    Vector3d xv(3);
     xv << 1.2767, -0.1756, -0.0394;
 
     //Pv
-    Matrix3f Pv(3,3);
+    Matrix3d Pv(3,3);
     Pv << 0.0004927, -0.0000653, -0.0000126,
 	 -0.0000653,  0.0001592,  0.0000369,
 	 -0.0000126,  0.0000369,  0.0000086;
 
     //xf
-    vector<Vector2f> xf;
-    Vector2f a(2);
+    vector<Vector2d> xf;
+    Vector2d a(2);
     a<<2.4261,-25.8041;
-    Vector2f b(2);
+    Vector2d b(2);
     b<<25.7095,3.2392;
     xf.push_back(a);
     xf.push_back(b);
 
     //Pf
-    vector<Matrix2f> Pf;
-    Matrix2f c(2,2);
+    vector<Matrix2d> Pf;
+    Matrix2d c(2,2);
     c<< 0.2019, 0.0133,
 	0.0133, 0.0109;
-    Matrix2f d(2,2);
+    Matrix2d d(2,2);
     d <<0.0131, -0.0239,
 	-0.0239, 0.1915;
     Pf.push_back(c);
@@ -742,10 +742,10 @@ TEST(FASTSLAM_TEST, sample_proposal_test)
     particle.setPf(Pf);
 
 
-    vector<Vector2f> zf;
-    Vector2f i(2);
+    vector<Vector2d> zf;
+    Vector2d i(2);
     i<<25.74325,-1.4901;
-    Vector2f j(2);
+    Vector2d j(2);
     j<<24.4729, 0.1353;
     zf.push_back(i);
     zf.push_back(j);
@@ -756,34 +756,34 @@ TEST(FASTSLAM_TEST, sample_proposal_test)
     idf.push_back(1);
 
     //R
-    Matrix2f R(2,2);
+    Matrix2d R(2,2);
     R<< 0.0100, 0,
 	0, 0.0003;
 
     sample_proposal(particle,zf, idf, R);
 
     // sample_proposal
-    float w_gt = 1.6005;
+    double w_gt = 1.6005;
     
-    Vector3f xv_gt(3);
+    Vector3d xv_gt(3);
     xv_gt<< 1.2935, -0.1718, -0.0387;
 
-    Matrix3f Pv_gt(3,3);
+    Matrix3d Pv_gt(3,3);
     Pv_gt.setZero();    
 
-    vector<Vector2f> xf_gt;
-    VectorXf e(2);
+    vector<Vector2d> xf_gt;
+    VectorXd e(2);
     a<<2.4261,-25.8041;
-    VectorXf f(2);
+    VectorXd f(2);
     b<<25.7095,3.2392;
     xf_gt.push_back(a);
     xf_gt.push_back(b);
  
-    vector<Matrix2f> Pf_gt;
-    Matrix2f g(2,2);
+    vector<Matrix2d> Pf_gt;
+    Matrix2d g(2,2);
     c<< 0.2019, 0.0133,
 	0.0133, 0.0109;
-    Matrix2f h(2,2);
+    Matrix2d h(2,2);
     d <<0.0131, -0.0239,
 	-0.0239, 0.1915;
     Pf_gt.push_back(c);
@@ -799,31 +799,31 @@ TEST(FASTSLAM_TEST, sample_proposal_test)
 TEST(FASTSLAM_TEST, likelihood_given_xv_test)
 {
     //w
-    float w = 0.01;
+    double w = 0.01;
 
     //xv
-    Vector3f xv(3);
+    Vector3d xv(3);
     xv << 1.2919, -0.1874,-0.0423;
 
     //Pv
-    Matrix3f Pv(3,3);
+    Matrix3d Pv(3,3);
     Pv.setZero();
 
     //xf
-    vector<Vector2f> xf;
-    VectorXf a(2);
+    vector<Vector2d> xf;
+    VectorXd a(2);
     a<<2.4261,-25.8041;
-    VectorXf b(2);
+    VectorXd b(2);
     b<<25.7095,3.2392;
     xf.push_back(a);
     xf.push_back(b);
 
     //Pf
-    vector<Matrix2f> Pf;
-    Matrix2f c(2,2);
+    vector<Matrix2d> Pf;
+    Matrix2d c(2,2);
     c<< 0.2019, 0.0133,
 	0.0133, 0.0109; 
-    Matrix2f d(2,2);
+    Matrix2d d(2,2);
     d<< 0.0131, -0.0239,
 	-0.0239,0.1915;
     Pf.push_back(c);
@@ -837,10 +837,10 @@ TEST(FASTSLAM_TEST, likelihood_given_xv_test)
     particle.setXf(xf);
     particle.setPf(Pf);
 
-    vector<Vector2f> zf;
-    Vector2f i(2);
+    vector<Vector2d> zf;
+    Vector2d i(2);
     i<<25.7432,-1.4901;
-    Vector2f j(2);
+    Vector2d j(2);
     j<<24.4729, 0.1353;
     zf.push_back(i);
     zf.push_back(j);
@@ -851,65 +851,65 @@ TEST(FASTSLAM_TEST, likelihood_given_xv_test)
     idf.push_back(1);
 
     //R
-    Matrix2f R(2,2);
+    Matrix2d R(2,2);
     R<< 0.0100, 0,
 	0, 0.0003;
    
-    float like = likelihood_given_xv(particle, zf,idf, R);
+    double like = likelihood_given_xv(particle, zf,idf, R);
     EXPECT_NE(like, 122.7224);
 }
 
 TEST(FASTSLAM_TEST, gauss_evaluate_test)
 {
    
-    VectorXf v(3);
+    VectorXd v(3);
     v<<-0.0480,-0.0286,-0.0069;
 
-    Matrix3f Pv0(3,3);
+    Matrix3d Pv0(3,3);
     Pv0<<0.0004977,-0.0000494, -0.0000091,
    -0.0000494,0.0001815,0.0000418,
    -0.0000091,0.0000418,0.0000097;
 
-    float prior_gt = 6378.3;
+    double prior_gt = 6378.3;
 
-    float prior = gauss_evaluate(v,Pv0,0);
+    double prior = gauss_evaluate(v,Pv0,0);
     #if 0
-    VectorXf v(3);
+    VectorXd v(3);
     v <<-0.0306, 0.0077, 0.0017;
 
-    MatrixXf Sf(3,3);
+    MatrixXd Sf(3,3);
     Sf << 0.0004983, -0.0000430, -0.0000089, 
 	-0.0000430, 0.0001697, 0.0000393,
 	-0.0000089, 0.0000393, 0.0000091;
-    float prior_gt = 603610;
-    float prior  = gauss_evaluate(v,Sf,0);
+    double prior_gt = 603610;
+    double prior  = gauss_evaluate(v,Sf,0);
     #endif
     #if 0
-    VectorXf v(2);
+    VectorXd v(2);
     v<< -1.18453, 1.62279;
     
-    Matrix2f Sf(2,2);
+    Matrix2d Sf(2,2);
     Sf<<0.020094, -0.000184015,
     -0.000184015,  0.000607922;
 
-    float prior = gauss_evaluate(v, Sf, 0);
-    float prior_gt = 0; 
+    double prior = gauss_evaluate(v, Sf, 0);
+    double prior_gt = 0; 
     #endif
     EXPECT_EQ(prior, prior_gt);
 }
 
 TEST(FASTSLAM_TEST, multivariate_gauss_test)
 {
-    VectorXf x(2);
+    VectorXd x(2);
     x<< 3.0000, -0.0087;
 
-    Matrix2f P(2,2);
+    Matrix2d P(2,2);
     P<< 0.09, 0,
          0, 0.0027;
 
     int n = 1;
-    VectorXf mg = multivariate_gauss(x,P,n);
-    VectorXf mg_gt(2);
+    VectorXd mg = multivariate_gauss(x,P,n);
+    VectorXd mg_gt(2);
     mg_gt << 0.1977, 0.2207;
     EXPECT_EQ(mg, mg_gt);
 }
@@ -943,7 +943,7 @@ TEST(FASTSLAM_TEST, resample_particles_test)
     int doresample = 1; 
     resample_particles(particles,Nmin,doresample);
 
-    vector<float> w_gt(10);
+    vector<double> w_gt(10);
     w_gt[0] = 0.0489;
     w_gt[1] = 0.1165;
     w_gt[2] = 0.0789;
@@ -962,34 +962,34 @@ TEST(FASTSLAM_TEST, resample_particles_test)
 
 TEST(FASTSLAM_TEST, misc_test)
 {
-    float like = 4.2596*pow(10.f,3.f);
-    float prior = 5.4764*pow(10.f,5.f);
-    float prop = 6.5415* pow(10.f,5.f);
-    float w_gt = 35.6746;
+    double like = 4.2596*pow(10.f,3.f);
+    double prior = 5.4764*pow(10.f,5.f);
+    double prop = 6.5415* pow(10.f,5.f);
+    double w_gt = 35.6746;
 
 
-    float a = prior/prop;
-    float b = 0.01 * a;
-    float newW = like * b;
+    double a = prior/prop;
+    double b = 0.01 * a;
+    double newW = like * b;
     EXPECT_EQ(newW, w_gt);
 
     #if 0
-    //Matrix2f P;
-    float total =0;
-    float particle_w= 1.28907*pow(10.0f,30.0f);
-    float like = 3135.09;
-    float prop = 3.07849*pow(10.0f,6.0f);
-    float prior = 3.1012*pow(10.0f,6.0f);
+    //Matrix2d P;
+    double total =0;
+    double particle_w= 1.28907*pow(10.0f,30.0f);
+    double like = 3135.09;
+    double prop = 3.07849*pow(10.0f,6.0f);
+    double prior = 3.1012*pow(10.0f,6.0f);
     
     cout<<"particle_w "<<particle_w<<endl;
     cout<<"like "<<like<<endl;
     cout<<"prop "<<prop<<endl;
     cout<<"prior "<<prior<<endl;
     cout<<"prop/prior "<<prop/prior<<endl;
-    float b = prop/prior;
+    double b = prop/prior;
     cout<<"particle_w * prop/prior "<<particle_w * b<<endl;
-    float c = particle_w * b;
-    float d = c* like;
+    double c = particle_w * b;
+    double d = c* like;
     cout<<"total "<< d<<endl;
     
     //P = nRandMat::randn(3,10);
@@ -1017,24 +1017,24 @@ TEST(FASTSLAM_TEST, misc_test)
 /*
     EXPECT_EQ(exp(2),7.3891);
     
-    MatrixXf S(3,3);
+    MatrixXd S(3,3);
     S<< 0.0004960, -0.0000521, -0.0000098,
     -0.0000521, 0.0001869, 0.0000430,
     -0.0000098, 0.0000430, 0.0000099;
 
-    MatrixXf cholMat = S.llt().matrixL();
+    MatrixXd cholMat = S.llt().matrixL();
 
-    MatrixXf Sc(3,3);
+    MatrixXd Sc(3,3);
     Sc<< 0.0223, 0, 0,
     -0.0023, 0.0121, 0,
     -0.0005, 0.0028, 0.0001;
     
-    VectorXf v(3);
+    VectorXd v(3);
     v<< -0.0081,-0.0135,-0.0033;
     
-    VectorXf nin = Sc.jacobiSvd(ComputeThinU | ComputeThinV).solve(v);
+    VectorXd nin = Sc.jacobiSvd(ComputeThinU | ComputeThinV).solve(v);
 
-    VectorXf nin_gt(3);
+    VectorXd nin_gt(3);
     nin_gt<<-0.3651,-1.1870,-0.6920;
     EXPECT_EQ(nin, nin_gt);
    

--- a/cpp/gtest/TestMatrixResizes.cpp
+++ b/cpp/gtest/TestMatrixResizes.cpp
@@ -1,13 +1,13 @@
 #include <gtest/gtest.h>
 #include <Eigen/Dense>
 
-using Eigen::MatrixXf;
-using Eigen::Matrix2f;
-using Eigen::Matrix3f;
+using Eigen::MatrixXd;
+using Eigen::Matrix2d;
+using Eigen::Matrix3d;
 
 TEST(FASTSLAM_TEST, basic_matrix_assign) {
-  MatrixXf m(2,2);
-  m = MatrixXf::Ones(2,2);
-  EXPECT_NO_THROW(Matrix2f m2 = m);
-  EXPECT_DEATH(Matrix3f m3 = m, "Invalid sizes when resizing a matrix or array.");
+  MatrixXd m(2,2);
+  m = MatrixXd::Ones(2,2);
+  EXPECT_NO_THROW(Matrix2d m2 = m);
+  EXPECT_DEATH(Matrix3d m3 = m, "Invalid sizes when resizing a matrix or array.");
 }


### PR DESCRIPTION
# Bug fix (Assertion in resample_particles.cpp) 
## Summary/Motivation:
There was an assertion failing in `resample_particles.cpp` in line 21.
The function `compute_weight.cpp` was yielding zero weights in line 40.
This was probably happening due to the low precision arithmetic of `floats` as opposed to `doubles`.
In fact, low precision was having a big effect on the inversion of the matrix S (covariance of the landmark estimation).
This matrix was becoming ill-conditioned and inverting him was leading to unstable results.
It should be noted, that the respective MATLAB code uses `doubles` and already worked smoothly, so it seems reasonable to also use `doubles` instead of `floats` in the C++ code. 
## Changes proposed in this PR:
To resolve this bug:
- all `floats` were replaced by `doubles`,
- all Eigen matrices and vectors of `floats` were converted to their `double` equivalents.